### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pylinac/vmat.py
+++ b/pylinac/vmat.py
@@ -429,11 +429,9 @@ class VMAT:
             passfail_str = 'FAIL'
 
         if _test_is_drgs(self.settings.test_type):
-            string = ('Dose Rate & Gantry Speed \nTest Results (Tol. +/-%2.1f%%): %s\n' %
-                      (self.settings.tolerance * 100, passfail_str))
+            string = ('Dose Rate & Gantry Speed \nTest Results (Tol. +/-{0:2.1f}%): {1!s}\n'.format(self.settings.tolerance * 100, passfail_str))
         elif _test_is_mlcs(self.settings.test_type):
-            string = ('Dose Rate & MLC Speed \nTest Results (Tol. +/-%2.1f%%): %s\n' %
-                      (self.settings.tolerance * 100, passfail_str))
+            string = ('Dose Rate & MLC Speed \nTest Results (Tol. +/-{0:2.1f}%): {1!s}\n'.format(self.settings.tolerance * 100, passfail_str))
 
         string += ('Max Deviation: %4.3f%%\n'
                    'Absolute Mean Deviation: %4.3f%%' %


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jrkerns:pylinac?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:jrkerns:pylinac?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)