### PR TITLE
[WIP] Supporting Elekta log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,99 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
                       "pyyaml >= 3.10",
                       "yagmail",
                       "mpld3",
-                      "reportlab >= 3.3"],
+                      "reportlab >= 3.3",
+                      "trf2csv"],
     entry_points={
         'console_scripts':
             ['pylinac=pylinac.scripts:cli']


### PR DESCRIPTION
Hi @jrkerns,

We have successfully set up high resolution logfile exporting and decoding from an Elekta linac. I have created a module called [trf2csv](https://gitlab.com/level-0/trf2csv)  which converts the Elekta `.trf` files to a basic `.csv` file.

I am proposing to write a pull request to pylinac to support Elekta logfile analysis within your `Log Analyzer` module. I am aiming to do this piece by piece in collaboration with you so that I align with the practices you have employed within pylinac.

Is this okay with you?