### PR TITLE
Allow for inputs in other units of temperature and pressure in tg51.p_tp()

### DIFF
--- a/pylinac/__init__.py
+++ b/pylinac/__init__.py
@@ -8,6 +8,12 @@ __version_info__ = (2, 0, 2)
 if sys.version_info[0] < 3:
     raise ValueError("Pylinac is only supported on Python 3.x. It seems you are using Python 2; please use a different interpreter.")
 
+
+from pint import UnitRegistry, set_application_registry
+ureg = UnitRegistry()
+set_application_registry(ureg)
+Q_ = ureg.Quantity
+
 # import shortcuts
 from pylinac.ct import CatPhan504, CatPhan600, CatPhan503
 from pylinac.core import decorators, geometry, image, io, mask, profile, roi, utilities

--- a/pylinac/tg51.py
+++ b/pylinac/tg51.py
@@ -16,6 +16,7 @@ from reportlab.lib.units import cm
 from .core.utilities import Structure
 from .core import pdf
 
+from . import Q_
 
 CHAMBERS_PHOTONS = {
     # Exradin
@@ -93,12 +94,22 @@ def p_tp(temp=22, press=760):
 
     Parameters
     ----------
-    temp : float
-        The temperature in degrees Celsius.
-    press : float
-        The pressure in mmHg.
+    temp : pint.Quantity (or float to be backwards compatible)
+        The temperature as pint.Quantity or as float.
+    press : pint.Quantity (or float to be backwards compatible)
+        The pressure as pint.Quantity or as float.
     """
-    return (760/press)*((273.2+temp)/295.2)
+    if type(temp) != Q_:
+        t = Q_(temp, 'celsius')
+    else:
+        t = temp
+
+    if type(press) != Q_:
+        p = Q_(press, 'mmHg')
+    else:
+        p = press
+
+    return (Q_(760, 'mmHg').to_base_units()/p.to_base_units()) * (t.to_base_units()/Q_(22, 'celsius').to_base_units())
 
 
 def p_pol(m_reference=(1, 2), m_opposite=(-3, -4)):
@@ -341,8 +352,8 @@ class TG51Photon(TG51Base):
 
     Attributes
     ----------
-    temp : float
-    press : float
+    temp : pint.Quantity (or float to be backwards compatible)
+    press : pint.Quantity (or float to be backwards compatible)
     energy : float
         Nominal energy of the beam in MV.
     model : str
@@ -505,8 +516,8 @@ class TG51Electron(TG51Base):
 
     Attributes
     ----------
-    temp : float
-    press : float
+    temp : pint.Quantity (or float to be backwards compatible)
+    press : pint.Quantity (or float to be backwards compatible)
     model : str
         Chamber model
     n_dw : float

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ click
 yagmail
 mpld3
 pyyaml
+pint

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ setup(
                       "tqdm == 3.8",
                       "pyyaml >= 3.10",
                       "yagmail",
-                      "reportlab >= 3.3"],
+                      "reportlab >= 3.3",
+                      "pint"],
     entry_points={
         'console_scripts':
             ['pylinac=pylinac.scripts:cli']

--- a/tests/test_tg51.py
+++ b/tests/test_tg51.py
@@ -1,14 +1,15 @@
 from unittest import TestCase
 
 from pylinac import tg51
+from pylinac import Q_
 
 
 class TestFunctions(TestCase):
 
     def test_p_tp(self):
-        temps = (22, 25, 19)
-        presss = (760, 770, 740)
-        expected_ptp = (1.0, 0.997, 1.0165)
+        temps = (22, 25, 19, Q_(22, 'celsius'), Q_(22, 'celsius').to('fahrenheit'))
+        presss = (760, 770, 740, Q_(760, 'mmHg'), Q_(760, 'mmHg').to('mbar'))
+        expected_ptp = (1.0, 0.997, 1.0165, 1.0, 1.0)
         for temp, press, exp in zip(temps, presss, expected_ptp):
             self.assertAlmostEqual(tg51.p_tp(temp, press), exp, delta=0.001)
 


### PR DESCRIPTION
This implements pint.Quantity inputs in tg51.p_tp() function to also allow inputs in other units, like for instance mbar or kPa. Backwards compatibility is maintained by type checking inputs.

I also extended the unittest to makek sure implemented changes work for the already present cases as well as the new option of pint.Quantity based inputs.