### PR TITLE
watcher.py trying to import old VMAT class

### DIFF
--- a/pylinac/watcher.py
+++ b/pylinac/watcher.py
@@ -22,7 +22,7 @@ from pylinac.core.io import retrieve_demo_file, is_dicom_image
 from pylinac.core.image import prepare_for_classification, DicomImage
 from pylinac.core import schedule
 
-from pylinac import VMAT, Starshot, PicketFence, WinstonLutz, LeedsTOR, StandardImagingQC3, load_log, LasVegas
+from pylinac import DRMLC, DRGS, Starshot, PicketFence, WinstonLutz, LeedsTOR, StandardImagingQC3, load_log, LasVegas
 from pylinac.log_analyzer import IMAGING
 
 logger = logging.getLogger("pylinac")


### PR DESCRIPTION
HI James

I've picked up on pylinac after a while and when I run it I get the error below running on Fedora 26. It seems as though line 25 of watcher.py is still trying to import the VMAT class. I've changed it to DRGS, DRMLC which seems to work (at least on the demo images). I've created a pull request on my fork.

Regards
Alan

Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/opt/pycharm-community-2018.2.2/helpers/pydev/_pydev_bundle/pydev_import_hook.py", line 20, in do_import
    module = self._system_import(name, *args, **kwargs)
  File "/home/alanphys/Programs/pylinac/pylinac/__init__.py", line 24, in <module>
    from pylinac.watcher import watch, process
  File "/opt/pycharm-community-2018.2.2/helpers/pydev/_pydev_bundle/pydev_import_hook.py", line 20, in do_import
    module = self._system_import(name, *args, **kwargs)
  File "/home/alanphys/Programs/pylinac/pylinac/watcher.py", line 25, in <module>
    from pylinac import VMAT, Starshot, PicketFence, WinstonLutz, LeedsTOR, StandardImagingQC3, load_log, LasVegas
ImportError: cannot import name 'VMAT'