### PR TITLE
Too many parameters in add_leaf_error_subplot in picketfence.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 # Folders to ignore
 env/*
 **/pylinac.egg-info
-#**/demo_files
+**/demo_files
 **/__pycache__
+**/.idea
 
 #Files to ignore
 *.old

--- a/pylinac/picketfence.py
+++ b/pylinac/picketfence.py
@@ -314,7 +314,7 @@ class PicketFence:
 
         # generate a leaf error subplot if desired
         if leaf_error_subplot:
-            self._add_leaf_error_subplot(ax, fig)
+            self._add_leaf_error_subplot(ax)
 
         # plot guard rails and mlc peaks as desired
         for p_num, picket in enumerate(self.pickets):


### PR DESCRIPTION
Hi James

I think you may have a parameter left over from when you removed the interactive plots in picketfence.py, plot_analyzed_image, add_leaf_error_subplot, line 317.

Regards
Alan