### PR TITLE
Use a copy of the DICOM pixel_array dataset for the DicomImage class

### DIFF
--- a/pylinac/core/image.py
+++ b/pylinac/core/image.py
@@ -704,7 +704,7 @@ class DicomImage(BaseImage):
         if dtype is not None:
             self.array = ds.pixel_array.astype(dtype)
         else:
-            self.array = ds.pixel_array
+            self.array = ds.pixel_array.copy()
         # convert values to HU or CU: real_values = slope * raw + intercept
         is_ct_storage = self.metadata.SOPClassUID.name == 'CT Image Storage'
         has_rescale_tags = hasattr(self.metadata, 'RescaleSlope') and hasattr(self.metadata, 'RescaleIntercept')


### PR DESCRIPTION
This change prevents ValueError's when trying to do things like `self.array -= foo` in the DicomArray class which currently cause a "ValueError: output array is read-only" exception to be raised.

Resolves Issue #303