### PR TITLE
Fix profile penumbra part deux

### DIFF
--- a/pylinac/core/profile.py
+++ b/pylinac/core/profile.py
@@ -285,7 +285,11 @@ class SingleProfile(ProfileMixin):
         max_point = y_data.max()
         threshold = max_point * (x / 100)
 
-        locs = np.where(y_data > threshold)[0]
+        # look for negative slope for RIGHT direction, postive slope for LEFT direction
+        grad = np.gradient(y_data)
+        cond = grad < 0 if side == RIGHT else grad > 0
+        locs = np.where((y_data > threshold) & cond)[0]
+
         peak = locs[-1] + 1 if side == RIGHT else locs[0] - 1
 
         if kind == VALUE:

--- a/pylinac/core/profile.py
+++ b/pylinac/core/profile.py
@@ -285,19 +285,8 @@ class SingleProfile(ProfileMixin):
         max_point = y_data.max()
         threshold = max_point * (x / 100)
 
-        # find the index, moving 1 element at a time until the value is encountered
-        found = False
-        at_end = False
-        try:
-            while not found and not at_end:
-                if y_data[peak] < threshold:
-                    found = True
-                    peak -= 1 if side == RIGHT else -1
-                elif peak == 0:
-                    at_end = True
-                peak += 1 if side == RIGHT else -1
-        except IndexError:
-            raise IndexError("The point of interest was beyond the profile; i.e. the profile may be cut off on the side")
+        locs = np.where(y_data > threshold)[0]
+        peak = locs[-1] + 1 if side == RIGHT else locs[0] - 1
 
         if kind == VALUE:
             return self._values_interp[peak] if interpolate else self.values[peak]

--- a/pylinac/core/profile.py
+++ b/pylinac/core/profile.py
@@ -289,12 +289,18 @@ class SingleProfile(ProfileMixin):
         if not_found:
             raise IndexError("The point of interest was beyond the profile; i.e. the profile may be cut off on the side")
 
-        # look for negative slope for RIGHT direction, postive slope for LEFT direction
+        # find all the points where the profile falls below the threshold and gradient
+        # is negative for the RIGHT side and positive for the left side
         grad = np.gradient(y_data)
         cond = grad < 0 if side == RIGHT else grad > 0
-        locs = np.where((y_data > threshold) & cond)[0]
+        locs = np.where((y_data <= threshold) & cond)[0]
 
-        peak = locs[-1] + 1 if side == RIGHT else locs[0] - 1
+        if side == RIGHT:
+            # Pick the left most index after the peak
+            peak = locs[np.where(locs >= peak)[0][0]]
+        else:
+            # Pick the rignt most index before the peak
+            peak = locs[np.where(locs <= peak)[0][-1]]
 
         if kind == VALUE:
             return self._values_interp[peak] if interpolate else self.values[peak]

--- a/pylinac/core/profile.py
+++ b/pylinac/core/profile.py
@@ -285,6 +285,10 @@ class SingleProfile(ProfileMixin):
         max_point = y_data.max()
         threshold = max_point * (x / 100)
 
+        not_found = len(np.where(y_data <= threshold)[0]) == 0
+        if not_found:
+            raise IndexError("The point of interest was beyond the profile; i.e. the profile may be cut off on the side")
+
         # look for negative slope for RIGHT direction, postive slope for LEFT direction
         grad = np.gradient(y_data)
         cond = grad < 0 if side == RIGHT else grad > 0

--- a/pylinac/planar_imaging.py
+++ b/pylinac/planar_imaging.py
@@ -738,7 +738,7 @@ class LeedsTOR(ImagePhantomBase):
 
         start_angle_deg = self._determine_start_angle_for_circle_profile()
         circle = self._circle_profile_for_phantom_angle(start_angle_deg)
-        peak_idx = circle.find_fwxm_peaks(threshold=0.6, max_number=1)[0]
+        peak_idx = circle.find_fwxm_peaks(threshold=0.6, x=80, max_number=1)[0]
 
         shift_percent = peak_idx / len(circle.values)
         shift_radians = shift_percent * 2 * np.pi
@@ -774,10 +774,11 @@ class LeedsTOR(ImagePhantomBase):
         """
 
         circle = self._circle_profile_for_phantom_angle(0)
-        peak_idx = circle.find_fwxm_peaks(threshold=0.6, max_number=1)[0]
+        peak_idx = circle.find_fwxm_peaks(threshold=0.6, x=80, max_number=1)[0]
         circle.values = np.roll(circle.values, -peak_idx)
         first_set = circle.find_peaks(search_region=(0.05, 0.45), threshold=0, min_distance=0.025, kind='value', max_number=9)
         second_set = circle.find_peaks(search_region=(0.55, 0.95), threshold=0, min_distance=0.025, kind='value', max_number=9)
+
         return max(first_set) > max(second_set)
 
     def _determine_start_angle_for_circle_profile(self) -> float:
@@ -801,7 +802,7 @@ class LeedsTOR(ImagePhantomBase):
         """
 
         circle = self._circle_profile_for_phantom_angle(0)
-        peak_idxs = circle.find_fwxm_peaks(threshold=0.6, max_number=4)
+        peak_idxs = circle.find_fwxm_peaks(threshold=0.6, x=80, max_number=4)
         on_left_half = [x < len(circle.values) / 2 for x in peak_idxs]
         aligned_to_zero_deg = not(all(on_left_half) or not any(on_left_half))
         return 90 if aligned_to_zero_deg else 0

--- a/pylinac/planar_imaging.py
+++ b/pylinac/planar_imaging.py
@@ -738,7 +738,7 @@ class LeedsTOR(ImagePhantomBase):
 
         start_angle_deg = self._determine_start_angle_for_circle_profile()
         circle = self._circle_profile_for_phantom_angle(start_angle_deg)
-        peak_idx = circle.find_fwxm_peaks(threshold=0.6, x=80, max_number=1)[0]
+        peak_idx = circle.find_fwxm_peaks(threshold=0.6, max_number=1)[0]
 
         shift_percent = peak_idx / len(circle.values)
         shift_radians = shift_percent * 2 * np.pi
@@ -774,7 +774,7 @@ class LeedsTOR(ImagePhantomBase):
         """
 
         circle = self._circle_profile_for_phantom_angle(0)
-        peak_idx = circle.find_fwxm_peaks(threshold=0.6, x=80, max_number=1)[0]
+        peak_idx = circle.find_fwxm_peaks(threshold=0.6, max_number=1)[0]
         circle.values = np.roll(circle.values, -peak_idx)
         first_set = circle.find_peaks(search_region=(0.05, 0.45), threshold=0, min_distance=0.025, kind='value', max_number=9)
         second_set = circle.find_peaks(search_region=(0.55, 0.95), threshold=0, min_distance=0.025, kind='value', max_number=9)
@@ -802,7 +802,7 @@ class LeedsTOR(ImagePhantomBase):
         """
 
         circle = self._circle_profile_for_phantom_angle(0)
-        peak_idxs = circle.find_fwxm_peaks(threshold=0.6, x=80, max_number=4)
+        peak_idxs = circle.find_fwxm_peaks(threshold=0.6, max_number=4)
         on_left_half = [x < len(circle.values) / 2 for x in peak_idxs]
         aligned_to_zero_deg = not(all(on_left_half) or not any(on_left_half))
         return 90 if aligned_to_zero_deg else 0


### PR DESCRIPTION
This is a replacement for PR #324 and includes a fix for LeedsTOR which broke due to improper peak detection.

Warning: I don't 100% understand the difference between threshold & x in `find_fwxm_peaks` and I need to investigate more whether it breaks anything else.  Any thoughts?