### PR TITLE
Pytest support

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+addopts = -n auto
+testpaths = 
+	tests_basic
+	tests_complete
+python_files = 
+	test_*.py
+	
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest-xdist

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ tqdm >= 3.8
 reportlab >= 3.3
 argue
 py-linq
+pytest-xdist


### PR DESCRIPTION
Adds support for pytest, allowing for parallel running of unit tests without breaking unittest compatibility. 
For context see issue #349 

Due to current test indexing structure, using pytest can only be run after first run of unittest. This is unavoidable 