### PR TITLE
Resolves issue #373 with updated WL tests

### DIFF
--- a/pylinac/winston_lutz.py
+++ b/pylinac/winston_lutz.py
@@ -281,7 +281,7 @@ class WinstonLutz:
             move += f"\nNew couch coordinates (mm): VRT: {new_vrt:3.2f}; LNG: {new_lng:3.2f}; LAT: {new_lat:3.2f}"
         return move
 
-    @argue.options(axis=(GANTRY, COLLIMATOR, COUCH, EPID, GBP_COMBO), value=('all', 'range'))
+    @argue.options(axis=(GANTRY, COLLIMATOR, COUCH, EPID, GBP_COMBO), value=('all', 'range', 'max'))
     def axis_rms_deviation(self, axis: str=GANTRY, value: str='all') -> float:
         """The RMS deviations of a given axis/axes.
 
@@ -304,6 +304,8 @@ class WinstonLutz:
         rms = [getattr(img, attr).as_scalar() for img in imgs]
         if value == 'range':
             rms = max(rms) - min(rms)
+        if value == 'max':
+            rms = max(rms)
         return rms
 
     @argue.options(metric=('max', 'median'))
@@ -560,13 +562,13 @@ class WinstonLutz:
         data['WL CAX->EPID 2D max (mm)'] = self.cax2epid_distance('max')
         data['WL CAX->EPID 2D median (mm)'] = self.cax2epid_distance('median')
         data['WL Collimator 2D iso size (mm)'] = self.collimator_iso_size
-        data['WL Collimator RMS deviations (mm)'] = self.axis_rms_deviation(axis=COLLIMATOR)
+        data['WL Collimator RMS deviations (mm)'] = self.axis_rms_deviation(axis=COLLIMATOR, value='max')
         data['WL # Coll images considered'] = num_coll_imgs
         data['WL Couch 2D iso size (mm)'] = self.couch_iso_size
-        data['WL Couch RMS deviations (mm)'] = self.axis_rms_deviation(axis=COUCH)
+        data['WL Couch RMS deviations (mm)'] = self.axis_rms_deviation(axis=COUCH, value='max')
         data['WL # Couch images considered'] = num_couch_imgs
         data['WL Gantry 3D iso size (mm)'] = self.gantry_iso_size
-        data['WL Gantry RMS deviations (mm)'] = self.axis_rms_deviation(axis=GANTRY)
+        data['WL Gantry RMS deviations (mm)'] = self.axis_rms_deviation(axis=GANTRY, value='max')
         data['WL # Gantry images considered'] = num_gantry_imgs
         data['WL Gantry+Coll 3D iso size (mm)'] = self.gantry_coll_iso_size
         data['WL # Gantry+Coll images considered'] = num_gantry_coll_imgs

--- a/tests_basic/test_winstonlutz.py
+++ b/tests_basic/test_winstonlutz.py
@@ -70,61 +70,62 @@ class TestResultsData(TestCase):
         cls.wl = WinstonLutz.from_demo_images()
 
     def test_results_data_cax2epid_max(self):
-        rd_result = self.wl.results_data()['cax2epid max']
+        rd_result = self.wl.results_data()['WL CAX->EPID 2D max (mm)']
         result = self.wl.cax2epid_distance('max')
         self.assertEqual(rd_result, result )
     def test_results_data_cax2epid_median(self):
-        rd_result = self.wl.results_data()['cax2epid median']
+        rd_result = self.wl.results_data()['WL CAX->EPID 2D median (mm)']
         result = self.wl.cax2epid_distance('median')
         self.assertEqual(rd_result, result )
 
     def test_results_data_cax2bb_max(self):
-        rd_result = self.wl.results_data()['cax2bb max']
+        rd_result = self.wl.results_data()['WL CAX->BB 2D max (mm)']
         result = self.wl.cax2bb_distance('max')
         self.assertEqual(rd_result, result ) 
     
     def test_results_data_cax2bb_median(self): 
-        rd_result = self.wl.results_data()['cax2bb median']
+        rd_result = self.wl.results_data()['WL CAX->BB 2D median (mm)']
         result = self.wl.cax2bb_distance('median')
         self.assertEqual(rd_result, result )
     
     def test_results_data_coll_iso_size(self):
-        rd_result = self.wl.results_data()['coll iso size']
+        rd_result = self.wl.results_data()['WL Collimator 2D iso size (mm)']
         result = self.wl.collimator_iso_size
         self.assertEqual(rd_result, result )
     
     def test_results_data_couch_iso_size(self):
-        rd_result = self.wl.results_data()['couch iso size']
+        rd_result = self.wl.results_data()['WL Couch 2D iso size (mm)']
         result = self.wl.couch_iso_size
         self.assertEqual(rd_result, result )
     
     def test_results_data_gantry_iso_size(self):
-        rd_result = self.wl.results_data()['gantry iso size']
+        rd_result = self.wl.results_data()['WL Gantry 3D iso size (mm)']
         result = self.wl.gantry_iso_size
         self.assertEqual(rd_result, result )
 
     def test_results_data_gantry_coll_iso_size(self):
-        rd_result = self.wl.results_data()['gantry coll iso size']
+        rd_result = self.wl.results_data()['WL Gantry+Coll 3D iso size (mm)']
         result = self.wl.gantry_coll_iso_size
         self.assertEqual(rd_result, result )        
 
     def test_results_data_mech_rad_x(self):
-        rd_result = self.wl.results_data()['MechRad x']
+        rd_result = self.wl.results_data()['WL Iso 3D position from BB']['x']
         result = -1* self.wl.bb_shift_vector.x
         self.assertEqual(rd_result, result)  
     def test_results_data_mech_rad_y(self):
-        rd_result = self.wl.results_data()['MechRad y']
+        rd_result = self.wl.results_data()['WL Iso 3D position from BB']['y']
         result = -1* self.wl.bb_shift_vector.y
         self.assertEqual(rd_result, result) 
     def test_results_data_mech_rad_z(self):
-        rd_result = self.wl.results_data()['MechRad z']
+        rd_result = self.wl.results_data()['WL Iso 3D position from BB']['z']
         result = -1* self.wl.bb_shift_vector.z
         self.assertEqual(rd_result, result) 
 
-    def test_results_data_gaxis_rms(self):
-        rd_result = self.wl.results_data()['axis rms dev']
-        result = self.wl.axis_rms_deviation
-        self.assertEqual(rd_result, result )  
+    def test_results_data_gantry_rms(self):
+        rd_result = self.wl.results_data()['WL Gantry RMS deviations (mm)']
+        result = self.wl.axis_rms_deviation(axis=GANTRY, value='max')
+        self.assertEqual(rd_result, result )
+
 
 class TestPublishPDF(TestCase):
 


### PR DESCRIPTION
Resolves issue #373 by creating a new max value for the rms method, which when invoked, returns the maximum of any list of rms values. For single axis calls this will always return the one value of interest and prevent single element arrays from being returned when not necessary. 

Updated tests to account for the updated Results_Data definitions of previous commits. 