### PR TITLE
Proposed change to correct asymmetric Profiler field values

### DIFF
--- a/pylinac/core/profile.py
+++ b/pylinac/core/profile.py
@@ -647,7 +647,7 @@ class SingleProfile(ProfileMixin):
                 round(field_right_idx)
             ),
             "field values": self._y_original_to_interp(
-                np.arange(int(round(field_left_idx)), int(round(field_right_idx)))
+                np.arange(int(round(field_left_idx)), int(round(field_right_idx))+1)
             ),
         }
         if self.dpmm:


### PR DESCRIPTION
A proposed change to the SingleProfile class to address asymmetric profile points stored in the horiz_profile and vert_profile classes.