### PR TITLE
follow clear borders setting during CatPhan module analysis

### DIFF
--- a/pylinac/ct.py
+++ b/pylinac/ct.py
@@ -575,6 +575,7 @@ class CTP404CP504(CatPhanModule):
         hu_tolerance: float,
         thickness_tolerance: float,
         scaling_tolerance: float,
+        clear_borders: bool=True,
     ):
         """
         Parameters
@@ -584,6 +585,7 @@ class CTP404CP504(CatPhanModule):
         hu_tolerance : float
         thickness_tolerance : float
         scaling_tolerance : float
+        clear_borders : bool
         """
         self.mm_per_pixel = catphan.mm_per_pixel
         self.hu_tolerance = hu_tolerance
@@ -591,7 +593,7 @@ class CTP404CP504(CatPhanModule):
         self.scaling_tolerance = scaling_tolerance
         self.thickness_rois = {}
         self.lines = {}
-        super().__init__(catphan, tolerance=hu_tolerance, offset=offset)
+        super().__init__(catphan, tolerance=hu_tolerance, offset=offset, clear_borders=clear_borders)
 
     def preprocess(self, catphan) -> None:
         # for the thickness analysis image, combine thin slices or just use one slice if slices are thick
@@ -604,6 +606,7 @@ class CTP404CP504(CatPhanModule):
             combine_method="mean",
             num_slices=self.num_slices + self.pad,
             slice_num=self.slice_num,
+            clear_borders = self.clear_borders,
         ).image
 
     def _setup_rois(self) -> None:
@@ -1349,11 +1352,13 @@ class CTP515(CatPhanModule):
         offset: int,
         contrast_method: Contrast,
         visibility_threshold: float,
+        clear_borders: bool=True,
     ):
         self.cnr_threshold = cnr_threshold
         self.contrast_method = contrast_method
         self.visibility_threshold = visibility_threshold
-        super().__init__(catphan, tolerance=tolerance, offset=offset)
+        super().__init__(catphan, tolerance=tolerance, offset=offset,
+                         clear_borders=clear_borders)
 
     def _setup_rois(self):
         # create both background rois dynamically, then create the actual sample ROI as normal
@@ -1997,13 +2002,23 @@ class CatPhanBase:
             hu_tolerance=hu_tolerance,
             thickness_tolerance=thickness_tolerance,
             scaling_tolerance=scaling_tolerance,
+            clear_borders=self.clear_borders,
         )
         if self._has_module(CTP486):
             ctp486, offset = self._get_module(CTP486)
-            self.ctp486 = ctp486(self, offset=offset, tolerance=hu_tolerance)
+            self.ctp486 = ctp486(
+                self, offset=offset,
+                tolerance=hu_tolerance,
+                clear_borders=self.clear_borders,
+            )
         if self._has_module(CTP528CP504):
             ctp528, offset = self._get_module(CTP528CP504)
-            self.ctp528 = ctp528(self, offset=offset, tolerance=None)
+            self.ctp528 = ctp528(
+                self,
+                offset=offset,
+                tolerance=None,
+                clear_borders=self.clear_borders
+            )
         if self._has_module(CTP515):
             ctp515, offset = self._get_module(CTP515)
             contrast_method = convert_to_enum(contrast_method, Contrast)
@@ -2014,6 +2029,7 @@ class CatPhanBase:
                 offset=offset,
                 contrast_method=contrast_method,
                 visibility_threshold=visibility_threshold,
+                clear_borders=self.clear_borders,
             )
         if zip_after and not self.was_from_zip:
             self._zip_images()


### PR DESCRIPTION
#448 
Use the clear_borders setting for initial localisation of CTP404 and also during analysis of each module.