### PR TITLE
Text results position changed in PicketFence.publish_pdf

### DIFF
--- a/pylinac/picketfence.py
+++ b/pylinac/picketfence.py
@@ -979,7 +979,7 @@ class PicketFence:
         self.save_analyzed_image(data, leaf_error_subplot=True)
         canvas.add_image(data, location=(3, 5), dimensions=(15, 15))
         canvas.add_text(
-            text=self.results(as_list=True), location=(1.5, 25), font_size=14
+            text=self.results(as_list=True), location=(1.5, 22), font_size=14
         )
         if notes is not None:
             canvas.add_text(text="Notes:", location=(1, 5.5), font_size=14)


### PR DESCRIPTION
Regarding issue #453

As can be see in line 40 from PylinacCanvas class

https://github.com/jrkerns/pylinac/blob/5894520e90d45d74a1a1d184eeed0121a2238afd/pylinac/core/pdf.py#L40

by default, metadata location is (2, 25.5). That is why the superposition when we call canvas.add_text(..., location = (1.5, 25), ...) in line 982 from picketfence.py

https://github.com/jrkerns/pylinac/blob/5894520e90d45d74a1a1d184eeed0121a2238afd/pylinac/picketfence.py#L981-L983

The new location to (1.5, 22) gives the posibility to show up to 7 metadata rows


![Captura](https://github.com/jrkerns/pylinac/assets/41806420/b3e130f6-e470-4ad1-ba2f-8b0e53294e64)
