### PR TITLE
Call crop method only if it is needed

### DIFF
--- a/pylinac/core/image.py
+++ b/pylinac/core/image.py
@@ -90,7 +90,8 @@ def equate_images(image1: ImageLike, image2: ImageLike) -> tuple[ImageLike, Imag
     else:
         img = image1
     pixel_height_diff = abs(int(round(-physical_height_diff * img.dpmm / 2)))
-    img.crop(pixel_height_diff, edges=("top", "bottom"))
+    if pixel_height_diff > 0:
+        img.crop(pixel_height_diff, edges=("top", "bottom"))
 
     # ...crop width
     physical_width_diff = image1.physical_shape[1] - image2.physical_shape[1]
@@ -99,7 +100,8 @@ def equate_images(image1: ImageLike, image2: ImageLike) -> tuple[ImageLike, Imag
     else:
         img = image2
     pixel_width_diff = abs(int(round(physical_width_diff * img.dpmm / 2)))
-    img.crop(pixel_width_diff, edges=("left", "right"))
+    if pixel_width_diff > 0:
+        img.crop(pixel_width_diff, edges=("left", "right"))
 
     # resize images to be of the same shape
     zoom_factor = image1.shape[1] / image2.shape[1]


### PR DESCRIPTION
Regarding issue #446

Call crop method only when pixel_difference > 0.