### PR TITLE
Remove Unused Dependency: Cached-property

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -70,14 +70,6 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
-name = "cached-property"
-version = "1.5.2"
-description = "A decorator for caching properties in classes."
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "cachetools"
 version = "5.2.0"
 description = "Extensible memoizing collections and decorators"
@@ -1035,10 +1027,6 @@ babel = [
 bump2version = [
     {file = "bump2version-1.0.1-py2.py3-none-any.whl", hash = "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410"},
     {file = "bump2version-1.0.1.tar.gz", hash = "sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6"},
-]
-cached-property = [
-    {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
-    {file = "cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"},
 ]
 cachetools = [
     {file = "cachetools-5.2.0-py3-none-any.whl", hash = "sha256:f9f17d2aec496a9aa6b76f53e3b614c965223c061982d434d160f930c698a9db"},

--- a/requirements-ram.txt
+++ b/requirements-ram.txt
@@ -4,7 +4,6 @@ atomicwrites==1.4.0
 attrs==21.4.0
 bleach==5.0.0
 bump2version==1.0.1
-cached-property==1.5.2
 certifi==2022.6.15
 charset-normalizer==2.0.12
 colorama==0.4.4


### PR DESCRIPTION
## Summary

This pull request removes the unused dependency `cached-property` from the `poetry.lock` and `requirements-ram.txt` configuration files. The removal of this dependency is a finding from ongoing research aimed at identifying and eliminating code bloat within software projects.

## Rationale

The `cached-property` library was first introduced to the project in f60d4e0. However, it was subsequently replaced by `functools.cached_property` in 42ac098. Despite its replacement in the source code, `cached-property` has persisted as a requirement in some of the project's dependency files. The removal of this now redundant dependency will reduce the app's footprint and streamline dependency management.

## Changes

- Removed the `cached-property` dependency from `poetry.lock`.
- Removed the `cached-property` dependency from `requirements-ram.txt`.

## Impact

- **Reduced Package Size**: By excluding the `cached-property` library, the overall size of the installed packages will be decreased.
- **Simplified Dependency Tree**: Reducing dependencies simplifies maintenance and can expedite installation.


