### PR TITLE
Determine metadata and set canvas

### DIFF
--- a/pylinac/picketfence.py
+++ b/pylinac/picketfence.py
@@ -1066,9 +1066,14 @@ class PicketFence:
         data = io.BytesIO()
         self.save_analyzed_image(data, leaf_error_subplot=True)
         canvas.add_image(data, location=(3, 5), dimensions=(15, 15))
-        canvas.add_text(
-            text=self.results(as_list=True), location=(1.5, 22), font_size=14
-        )
+        if metadata:
+            canvas.add_text(
+                text=self.results(as_list=True), location=(1.5, 22), font_size=14
+            )
+        else:
+            canvas.add_text(
+                text=self.results(as_list=True), location=(1.5, 25), font_size=14
+            )
         if notes is not None:
             canvas.add_text(text="Notes:", location=(1, 5.5), font_size=14)
             canvas.add_text(text=notes, location=(1, 5))


### PR DESCRIPTION
If the image I use is from top to bottom, the text will cover the analyzed image.And I don’t need to set metadata, so I need to set it through this configuration 
![1338F9EA-4B5B-4e30-8710-5BC89D56273D](https://github.com/jrkerns/pylinac/assets/40515845/0c69d400-ffa4-4d14-b35c-a93dffc3891e)


