### PR TITLE
fix: correct link to CIRS062M phantom

### DIFF
--- a/pylinac/cheese.py
+++ b/pylinac/cheese.py
@@ -675,7 +675,7 @@ class CIRS062M(CheesePhantomBase):
 
     See Also
     --------
-    https://www.cirsinc.com/products/radiation-therapy/electron-density-phantom/
+    https://www.cirsinc.com/products/all/24/electron-density-phantom/
     """
 
     model = "CIRS Electron Density (062M)"


### PR DESCRIPTION
This corrects the link in the documentation to link to the correct phantom

refs: #496