### PR TITLE
Add access to Dicom Metadata 

### DIFF
--- a/pylinac/ct.py
+++ b/pylinac/ct.py
@@ -2421,6 +2421,11 @@ class CatPhanBase(ResultsDataMixin[CatphanResult], QuaacMixin):
             modules.append(self.ctp528)
         return modules
 
+    @property
+    def dicomMetadata(self) -> dict:
+        """The metadata of the first DICOM file."""
+        return self.centralSlice.metadata
+
     def analyze(
         self,
         hu_tolerance: int | float = 40,


### PR DESCRIPTION
Added dictionary property containing the [FileDataset](https://pydicom.github.io/pydicom/dev/reference/generated/pydicom.dataset.FileDataset.html) information for the central slice of the CT scan. 

Please change if you'd rather see different names. Possible solution to #534 