### PR TITLE
Update winston_lutz.py

### DIFF
--- a/pylinac/winston_lutz.py
+++ b/pylinac/winston_lutz.py
@@ -2316,19 +2316,19 @@ class WinstonLutz(ResultsDataMixin[WinstonLutzResult], QuaacMixin):
             images = [
                 image
                 for image in self.images
-                if image.variable_axis in (Axis.GANTRY, Axis.REFERENCE)
+                if hasattr(image.variable_axis, 'GANTRY') and image.variable_axis.GANTRY in (Axis.GANTRY, Axis.REFERENCE)
             ]
         elif axis == Axis.COLLIMATOR:
             images = [
                 image
                 for image in self.images
-                if image.variable_axis in (Axis.COLLIMATOR, Axis.REFERENCE)
+                if hasattr(image.variable_axis, 'COLLIMATOR') and image.variable_axis.COLLIMATOR in (Axis.COLLIMATOR, Axis.REFERENCE)
             ]
         elif axis == Axis.COUCH:
             images = [
                 image
                 for image in self.images
-                if image.variable_axis in (Axis.COUCH, Axis.REFERENCE)
+                if hasattr(image.variable_axis, 'COUCH') and image.variable_axis.COUCH in (Axis.COUCH, Axis.REFERENCE)
             ]
         elif axis == Axis.GB_COMBO:
             images = [


### PR DESCRIPTION
I apologize if this is a failing of using the program on my side. I greatly appreciate PyLinac and how it has helped me and the clinic I'm a part of.

The reason I made this change is that when running wl.plot_images() it was unable to correctly split the images based on the presented axis (axis==Axis.GANTRY, COLLIMATOR, etc.)

I'm at an ELEKTA site and am using the axis_mapping feature to establish gantry, collimator, couch angles.

The program runs as expected after applying this change, and I believe it would not detrimentally impact those currently using the program.

Thank you!