### PR TITLE
Mark tests as proprietary

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -44,7 +44,7 @@ definitions:
           - chmod +x memory_monitor.sh
           - nohup ./memory_monitor.sh &
           - MONITOR_PID=$!
-          - uv run pytest tests_basic/test_cbct.py -n 2 --cov=pylinac.cbct --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_cbct.py -n 2 --cov=pylinac.cbct --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
           # clean up memory monitor
           - kill $MONITOR_PID
         caches:
@@ -65,7 +65,7 @@ definitions:
           - chmod +x memory_monitor.sh
           - nohup ./memory_monitor.sh &
           - MONITOR_PID=$!
-          - uv run pytest tests_basic/test_quart.py --cov=pylinac.quart --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_quart.py --cov=pylinac.quart --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
           # clean up memory monitor
           - kill $MONITOR_PID
         artifacts:
@@ -87,7 +87,7 @@ definitions:
           - chmod +x memory_monitor.sh
           - nohup ./memory_monitor.sh &
           - MONITOR_PID=$!
-          - uv run pytest tests_basic/test_acr.py --cov=pylinac.acr --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_acr.py --cov=pylinac.acr --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
           # clean up memory monitor
           - kill $MONITOR_PID
         artifacts:
@@ -109,7 +109,7 @@ definitions:
           - chmod +x memory_monitor.sh
           - nohup ./memory_monitor.sh &
           - MONITOR_PID=$!
-          - uv run pytest tests_basic/test_cheese.py --cov=pylinac.cheese --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_cheese.py --cov=pylinac.cheese --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
           # clean up memory monitor
           - kill $MONITOR_PID
         artifacts:
@@ -131,7 +131,7 @@ definitions:
           - chmod +x memory_monitor.sh
           - nohup ./memory_monitor.sh &
           - MONITOR_PID=$!
-          - uv run pytest tests_basic/test_planar_imaging.py --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_planar_imaging.py --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
           # clean up memory monitor
           - kill $MONITOR_PID
         artifacts:
@@ -147,7 +147,7 @@ definitions:
     - step: &dlg-tests
         name: Run DLG Tests
         script:
-          - uv run pytest tests_basic/test_dlg.py --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_dlg.py --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
         caches:
           - testfiles
         condition:
@@ -159,7 +159,7 @@ definitions:
     - step: &field-analysis-tests
         name: Run Field Analysis Tests
         script:
-          - uv run pytest tests_basic/test_field_analysis.py --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_field_analysis.py --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
         caches:
           - testfiles
         condition:
@@ -171,7 +171,7 @@ definitions:
     - step: &machine-log-tests
         name: Run Machine Logs Tests
         script:
-          - uv run pytest tests_basic/test_logs.py --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_logs.py --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
         caches:
           - testfiles
         condition:
@@ -188,7 +188,7 @@ definitions:
           - chmod +x memory_monitor.sh
           - nohup ./memory_monitor.sh &
           - MONITOR_PID=$!
-          - uv run pytest tests_basic/test_picketfence.py --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_picketfence.py --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
           # clean up memory monitor
           - kill $MONITOR_PID
         artifacts:
@@ -204,7 +204,7 @@ definitions:
     - step: &starshot-tests
         name: Run Starshot Tests
         script:
-          - uv run pytest tests_basic/test_starshot.py --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_starshot.py --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
         caches:
           - testfiles
         condition:
@@ -216,7 +216,7 @@ definitions:
     - step: &calibration-tests
         name: Run TG-51/TRS-398 Tests
         script:
-          - uv run pytest tests_basic/test_tg51.py tests_basic/test_trs398.py --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_tg51.py tests_basic/test_trs398.py --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
         caches:
           - testfiles
         condition:
@@ -229,7 +229,7 @@ definitions:
     - step: &vmat-tests
         name: Run VMAT Tests
         script:
-          - uv run pytest tests_basic/test_vmat.py --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_vmat.py --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
         caches:
           - testfiles
         condition:
@@ -246,7 +246,7 @@ definitions:
           - chmod +x memory_monitor.sh
           - nohup ./memory_monitor.sh &
           - MONITOR_PID=$!
-          - uv run pytest tests_basic/test_winstonlutz.py --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_winstonlutz.py --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
           # clean up memory monitor
           - kill $MONITOR_PID
         condition:
@@ -265,7 +265,7 @@ definitions:
           - chmod +x memory_monitor.sh
           - nohup ./memory_monitor.sh &
           - MONITOR_PID=$!
-          - uv run pytest tests_basic/test_winstonlutz_mtmf.py --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_winstonlutz_mtmf.py --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
           # clean up memory monitor
           - kill $MONITOR_PID
         condition:
@@ -279,7 +279,7 @@ definitions:
     - step: &plan-generator-tests
         name: Plan generator tests
         script:
-          - uv run pytest tests_basic/test_plan_generator.py tests_basic/test_generated_plans.py --cov-report term --junitxml=./test-reports/pytest_results.xml
+          - uv run pytest tests_basic/test_plan_generator.py tests_basic/test_generated_plans.py --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
         condition:
             changesets:
                 includePaths:
@@ -290,8 +290,7 @@ definitions:
     - step: &core-module-tests
         name: Run core module tests
         script:
-          - uv run pytest tests_basic/core --cov-report term --junitxml=./test-reports/pytest_results.xml
-        caches:
+          - uv run pytest tests_basic/core --cov-report term --junitxml=./test-reports/pytest_results.xml -m 'proprietary or not proprietary'
           - testfiles
         condition:
           changesets:

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,6 +18,7 @@ def run_min_version_test(session):
         "run",
         "pytest",
         "tests_basic/core",
+        "-m 'proprietary or not proprietary'",
         env={"UV_PROJECT_ENVIRONMENT": py_str, "VIRTUAL_ENV": py_str},
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,13 +82,14 @@ exclude = ['pylinac/demo_files/**']
 [tool.pytest.ini_options]
 testpaths = "tests_basic"
 python_files = "test_*.py"
-addopts = "--dist loadscope"
+addopts = "--dist loadscope -m 'not proprietary'"
 filterwarnings = [
     "ignore::UserWarning:pydicom",
     "ignore:FigureCanvasAgg.*:UserWarning"
     ]
 markers = [
     'catphan604',
+    'proprietary',
 ]
 
 [tool.coverage.run]

--- a/tests_basic/conftest.py
+++ b/tests_basic/conftest.py
@@ -1,0 +1,60 @@
+import pytest
+from tests_basic.utils import get_file_from_cloud_test_repo, get_folder_from_cloud_repo
+
+
+@pytest.fixture(scope="session")
+def anonymous_source_folder():
+    return get_folder_from_cloud_repo(["mlc_logs", "_anonbase"])
+
+
+@pytest.fixture(scope="session")
+def anonymous_dest_folder():
+    return get_folder_from_cloud_repo(["mlc_logs", "anonymous"])
+
+
+@pytest.fixture(scope="session")
+def test_files():
+    return get_folder_from_cloud_repo(["test_files"])
+
+
+@pytest.fixture(scope="session")
+def bad_tif_path():
+    return get_file_from_cloud_test_repo(["Winston-Lutz", "AQA_A_03082023.tif"])
+
+
+@pytest.fixture(scope="session")
+def tif_path():
+    return get_file_from_cloud_test_repo(["Starshot", "Starshot-1.tif"])
+
+
+@pytest.fixture(scope="session")
+def png_path():
+    return get_file_from_cloud_test_repo(["Starshot", "Starshot-1.png"])
+
+
+@pytest.fixture(scope="session")
+def dcm_path():
+    return get_file_from_cloud_test_repo(["VMAT", "DRGSdmlc-105-example.dcm"])
+
+
+@pytest.fixture(scope="session")
+def as500_path():
+    return get_file_from_cloud_test_repo(["picket_fence", "AS500#5.dcm"])
+
+
+@pytest.fixture(scope="session")
+def xim_path():
+    return get_file_from_cloud_test_repo(["ximdcmtest.xim"])
+
+
+@pytest.fixture(scope="session")
+def xim_dcm_path():
+    return get_file_from_cloud_test_repo(["ximdcmtest.dcm"])
+
+@pytest.fixture(scope="session")
+def rt_plan_file():
+    return get_file_from_cloud_test_repo(["plan_generator", "Murray-plan.dcm"])
+
+@pytest.fixture(scope="session")
+def halcyon_plan_file():
+    return get_file_from_cloud_test_repo(["plan_generator", "Halcyon Prox.dcm"])

--- a/tests_basic/contrib/test_orthogonality.py
+++ b/tests_basic/contrib/test_orthogonality.py
@@ -1,3 +1,4 @@
+import pytest
 from pathlib import Path
 from unittest import TestCase
 
@@ -5,6 +6,7 @@ from pylinac.contrib.orthogonality import JawOrthogonality
 from tests_basic.utils import get_folder_from_cloud_repo
 
 
+@pytest.mark.proprietary
 class TestOrthogonality(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/tests_basic/contrib/test_quasar.py
+++ b/tests_basic/contrib/test_quasar.py
@@ -1,3 +1,4 @@
+import pytest
 from pathlib import Path
 from unittest import TestCase
 
@@ -5,6 +6,7 @@ from pylinac.contrib.quasar import QuasarLightRadScaling
 from tests_basic.utils import get_folder_from_cloud_repo
 
 
+@pytest.mark.proprietary
 class TestQuasar(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/tests_basic/core/test_gamma.py
+++ b/tests_basic/core/test_gamma.py
@@ -1,4 +1,5 @@
 import math
+import pytest
 from unittest import TestCase, skip
 
 import numpy as np
@@ -12,6 +13,7 @@ from tests_basic.core.test_profile import generate_open_field
 from tests_basic.utils import get_file_from_cloud_test_repo
 
 
+@pytest.mark.proprietary
 class TestAgnewMcGarry(TestCase):
     """Tests from the Agnew & McGarry paper. https://www.sciencedirect.com/science/article/abs/pii/S0167814015006660"""
 
@@ -794,6 +796,7 @@ class TestGammaFromProfile(TestCase):
         # gamma is perfect
         self.assertTrue(np.allclose(gamma, 0))
 
+    @pytest.mark.proprietary
     def test_different_epids(self):
         """This test the same profile but with different EPIDs (i.e. pixel size)"""
         img1200 = generate_open_field(field_size=(100, 100), imager=AS1200Image)

--- a/tests_basic/core/test_image.py
+++ b/tests_basic/core/test_image.py
@@ -2,6 +2,16 @@ import copy
 import io
 import json
 import os
+from tests_basic.conftest import (
+    as500_path,
+    bad_tif_path,
+    dcm_path,
+    png_path,
+    tif_path,
+    xim_dcm_path,
+    xim_path,
+)
+import pytest
 import shutil
 import tempfile
 import unittest
@@ -43,13 +53,9 @@ from tests_basic.utils import (
     save_file,
 )
 
-bad_tif_path = get_file_from_cloud_test_repo(["Winston-Lutz", "AQA_A_03082023.tif"])
-tif_path = get_file_from_cloud_test_repo(["Starshot", "Starshot-1.tif"])
-png_path = get_file_from_cloud_test_repo(["Starshot", "Starshot-1.png"])
-dcm_path = get_file_from_cloud_test_repo(["VMAT", "DRGSdmlc-105-example.dcm"])
-as500_path = get_file_from_cloud_test_repo(["picket_fence", "AS500#5.dcm"])
-xim_path = get_file_from_cloud_test_repo(["ximdcmtest.xim"])
-xim_dcm_path = get_file_from_cloud_test_repo(["ximdcmtest.dcm"])
+pytestmark = pytest.mark.proprietary
+
+
 dcm_url = "https://storage.googleapis.com/pylinac_demo_files/EPID-PF-LR.dcm"
 
 
@@ -793,7 +799,9 @@ class TestArrayImage(TestCase):
 
 
 class TestDicomStack(TestCase):
-    stack_location = get_file_from_cloud_test_repo(["CBCT", "CBCT_4.zip"])
+    @classmethod
+    def setUpClass(cls):
+        cls.stack_location = get_file_from_cloud_test_repo(["CBCT", "CBCT_4.zip"])
 
     def test_loading(self):
         # test normal construction

--- a/tests_basic/core/test_image_metrics.py
+++ b/tests_basic/core/test_image_metrics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from unittest import TestCase
 
 import numpy as np
@@ -112,6 +113,7 @@ class TestGeneralMetric(TestCase):
             )
 
 
+@pytest.mark.proprietary
 class TestGlobalDiskLocator(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/tests_basic/core/test_io.py
+++ b/tests_basic/core/test_io.py
@@ -2,6 +2,7 @@
 
 import os
 import os.path as osp
+import pytest
 import unittest
 
 from pylinac import Interpolation
@@ -14,6 +15,9 @@ from pylinac.core.io import (
 )
 from pylinac.core.profile import SingleProfile
 from tests_basic.utils import get_file_from_cloud_test_repo
+
+
+pytestmark = pytest.mark.proprietary
 
 
 class TestIO(unittest.TestCase):

--- a/tests_basic/core/test_profile.py
+++ b/tests_basic/core/test_profile.py
@@ -1,3 +1,4 @@
+import pytest
 import warnings
 from typing import Any
 from unittest import TestCase
@@ -2307,7 +2308,6 @@ class MultiProfileTriangle(MultiProfileTestMixin, TestCase):
 
 class CircleProfileTestMixin:
     klass = CircleProfile
-    image_file_location = get_file_from_cloud_test_repo(["Starshot", "Starshot-1.tif"])
     radius = 300
     peak_idxs = (0,)
     valley_idxs = (0,)
@@ -2316,7 +2316,8 @@ class CircleProfileTestMixin:
 
     @classmethod
     def setUpClass(cls):
-        img = image.load(cls.image_file_location)
+        image_file_location = get_file_from_cloud_test_repo(["Starshot", "Starshot-1.tif"])
+        img = image.load(image_file_location)
         cls.profile = cls.klass(cls.center_point, cls.radius, img.array)
         cls.profile.filter(size=0.01, kind="gaussian")
 
@@ -2343,12 +2344,14 @@ class CircleProfileTestMixin:
         self.profile.plot2axes()
 
 
+@pytest.mark.proprietary
 class CircleProfileStarshot(CircleProfileTestMixin, TestCase):
     peak_idxs = [219, 480, 738, 984, 1209, 1421, 1633, 1864]
     valley_idxs = [95, 348, 607, 860, 1098, 1316, 1527, 1743]
     fwxm_peak_idxs = [218, 480, 738, 984, 1209, 1421, 1633, 1864]
 
 
+@pytest.mark.proprietary
 class CollapsedCircleProfileStarshot(CircleProfileTestMixin, TestCase):
     klass = CollapsedCircleProfile
     peak_idxs = [241, 529, 812, 1084, 1331, 1563, 1797, 2051]

--- a/tests_basic/test_acr.py
+++ b/tests_basic/test_acr.py
@@ -1,5 +1,6 @@
 import io
 import os
+import pytest
 from pathlib import Path
 from unittest import TestCase
 
@@ -19,6 +20,8 @@ from tests_basic.utils import (
     get_file_from_cloud_test_repo,
     save_file,
 )
+
+pytestmark = pytest.mark.proprietary
 
 TEST_DIR_CT = ["ACR", "CT"]
 TEST_DIR_MR = ["ACR", "MRI"]

--- a/tests_basic/test_cbct.py
+++ b/tests_basic/test_cbct.py
@@ -4,6 +4,7 @@ import io
 import json
 import os
 import os.path as osp
+import pytest
 import tempfile
 from unittest import TestCase, skip
 
@@ -35,6 +36,7 @@ from tests_basic.utils import (
 TEST_DIR = "CBCT"
 
 
+@pytest.mark.proprietary
 class TestInstantiation(
     TestCase,
     InitTesterMixin,
@@ -86,6 +88,7 @@ class TestCBCT504ResultsData(TestCase, ResultsDataBase):
     model = CatPhan504
 
 
+@pytest.mark.proprietary
 class TestGeneral(TestCase):
     """Test general things when using cbct module."""
 
@@ -539,6 +542,7 @@ class CatPhanDemo(CatPhanMixin, TestCase):
         cls.cbct.analyze()
 
 
+@pytest.mark.proprietary
 class CatPhan4(CatPhanMixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -560,6 +564,7 @@ class CatPhan4(CatPhanMixin, TestCase):
     slice_thickness = 2.4
 
 
+@pytest.mark.proprietary
 class Elekta2(CatPhanMixin, TestCase):
     """An Elekta CBCT dataset"""
 
@@ -597,6 +602,7 @@ class Elekta2(CatPhanMixin, TestCase):
             )
 
 
+@pytest.mark.proprietary
 class CatPhan600_2(CatPhanMixin, TestCase):
     """An Elekta CBCT dataset"""
 
@@ -621,6 +627,7 @@ class CatPhan600_2(CatPhanMixin, TestCase):
     lowcon_visible = 2  # changed w/ visibility refactor in v3.0
 
 
+@pytest.mark.proprietary
 class CatPhan600WaterVial(CatPhanMixin, TestCase):
     """Scan with the water vial in place"""
 
@@ -650,6 +657,7 @@ class CatPhan600WaterVial(CatPhanMixin, TestCase):
         self.assertIn("Vial", self.cbct.ctp404.rois)
 
 
+@pytest.mark.proprietary
 class CatPhan600WaterVial2(CatPhanMixin, TestCase):
     """Scan with the water vial in place. This broke the MTF algo previously."""
 
@@ -679,6 +687,7 @@ class CatPhan600WaterVial2(CatPhanMixin, TestCase):
         self.assertIn("Vial", self.cbct.ctp404.rois)
 
 
+@pytest.mark.proprietary
 class CatPhan600DirectDensity(CatPhanMixin, TestCase):
     """Direct density scan."""
 
@@ -706,6 +715,7 @@ class CatPhan600DirectDensity(CatPhanMixin, TestCase):
     lowcon_visible = 6
 
 
+@pytest.mark.proprietary
 @mark.catphan604
 class CatPhan604Test(CatPhanMixin, TestCase):
     catphan = CatPhan604
@@ -728,6 +738,7 @@ class CatPhan604Test(CatPhanMixin, TestCase):
     avg_noise_power = 0.252
 
 
+@pytest.mark.proprietary
 @mark.catphan604
 class CatPhan604TestROIOffsets(CatPhan604Test):
     # random, arbitrary offsets applied for a constancy test against adjustment changes
@@ -770,6 +781,7 @@ class CatPhan604Mixin(CatPhanMixin):
     dir_path = [TEST_DIR, "CatPhan_604"]
 
 
+@pytest.mark.proprietary
 class VarianPelvis(CatPhan504Mixin, TestCase):
     """Test the Varian Pelvis protocol CBCT."""
 
@@ -792,6 +804,7 @@ class VarianPelvis(CatPhan504Mixin, TestCase):
     slice_thickness = 2.5
 
 
+@pytest.mark.proprietary
 class VarianPelvisSpotlight(CatPhan504Mixin, TestCase):
     """Test the Varian Pelvis Spotlight protocol CBCT."""
 
@@ -814,6 +827,7 @@ class VarianPelvisSpotlight(CatPhan504Mixin, TestCase):
     slice_thickness = 2.4
 
 
+@pytest.mark.proprietary
 class VarianLowDoseThorax(CatPhan504Mixin, TestCase):
     """Test the Varian Low-Dose Thorax protocol CBCT."""
 
@@ -836,6 +850,7 @@ class VarianLowDoseThorax(CatPhan504Mixin, TestCase):
     slice_thickness = 2.4
 
 
+@pytest.mark.proprietary
 class VarianStandardHead(CatPhan504Mixin, TestCase):
     """Test the Varian Standard Head protocol CBCT."""
 
@@ -858,6 +873,7 @@ class VarianStandardHead(CatPhan504Mixin, TestCase):
     slice_thickness = 2.4
 
 
+@pytest.mark.proprietary
 class VarianLowDoseHead(CatPhan504Mixin, TestCase):
     """Test the Varian Low-Dose Head protocol CBCT."""
 
@@ -901,6 +917,7 @@ class GEMonthlyCT(CatPhan504Mixin, TestCase):
     lowcon_visible = 4
 
 
+@pytest.mark.proprietary
 class ToshibaMonthlyCT(CatPhan504Mixin, TestCase):
     """Test a monthly CT scan from Toshiba."""
 
@@ -921,6 +938,7 @@ class ToshibaMonthlyCT(CatPhan504Mixin, TestCase):
     slice_thickness = 2.8
 
 
+@pytest.mark.proprietary
 class CBCT1(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -955,6 +973,7 @@ class CBCT1(CatPhan504Mixin, TestCase):
             )
 
 
+@pytest.mark.proprietary
 class CBCT2(CatPhan504Mixin, PlotlyTestMixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -1013,6 +1032,7 @@ class CBCT2(CatPhan504Mixin, PlotlyTestMixin, TestCase):
         self.instance = self.cbct
 
 
+@pytest.mark.proprietary
 class CBCT3(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -1038,6 +1058,7 @@ class CBCT3(CatPhan504Mixin, TestCase):
 # CBCT4 is in the regular test_cbct.py file
 
 
+@pytest.mark.proprietary
 class CBCT5(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -1059,6 +1080,7 @@ class CBCT5(CatPhan504Mixin, TestCase):
     slice_thickness = 2.35
 
 
+@pytest.mark.proprietary
 class CBCT6(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -1081,6 +1103,7 @@ class CBCT6(CatPhan504Mixin, TestCase):
     slice_thickness = 2.35
 
 
+@pytest.mark.proprietary
 class CBCT7(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -1103,6 +1126,7 @@ class CBCT7(CatPhan504Mixin, TestCase):
     slice_thickness = 2.3
 
 
+@pytest.mark.proprietary
 class CBCT8(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -1126,6 +1150,7 @@ class CBCT8(CatPhan504Mixin, TestCase):
     slice_thickness = 2.3
 
 
+@pytest.mark.proprietary
 class CBCT9(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -1148,6 +1173,7 @@ class CBCT9(CatPhan504Mixin, TestCase):
     slice_thickness = 2.4
 
 
+@pytest.mark.proprietary
 class CBCT10(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -1169,6 +1195,7 @@ class CBCT10(CatPhan504Mixin, TestCase):
     slice_thickness = 2.3
 
 
+@pytest.mark.proprietary
 class CBCT11(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -1192,6 +1219,7 @@ class CBCT11(CatPhan504Mixin, TestCase):
     avg_noise_power = 0.226
 
 
+@pytest.mark.proprietary
 class CBCT12(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -1213,6 +1241,7 @@ class CBCT12(CatPhan504Mixin, TestCase):
     slice_thickness = 2.35
 
 
+@pytest.mark.proprietary
 class CBCT13(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -1235,6 +1264,7 @@ class CBCT13(CatPhan504Mixin, TestCase):
     slice_thickness = 2.5
 
 
+@pytest.mark.proprietary
 class CBCT14(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -1257,6 +1287,7 @@ class CBCT14(CatPhan504Mixin, TestCase):
     slice_thickness = 2.4
 
 
+@pytest.mark.proprietary
 class CBCT15(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset."""
 
@@ -1276,6 +1307,7 @@ class CBCT15(CatPhan504Mixin, TestCase):
     lowcon_visible = 6
 
 
+@pytest.mark.proprietary
 class CBCT16(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -1298,6 +1330,7 @@ class CBCT16(CatPhan504Mixin, TestCase):
     slice_thickness = 2.4
 
 
+@pytest.mark.proprietary
 class CBCT17(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset"""
 
@@ -1319,6 +1352,7 @@ class CBCT17(CatPhan504Mixin, TestCase):
     lowcon_visible = 1
 
 
+@pytest.mark.proprietary
 class Catphan504Ring(CatPhan504Mixin, TestCase):
     """A Varian CBCT dataset with ring artifact"""
 
@@ -1341,6 +1375,7 @@ class Catphan504Ring(CatPhan504Mixin, TestCase):
     slice_thickness = 2.5
 
 
+@pytest.mark.proprietary
 class Katy1(CatPhan504Mixin, TestCase):
     """CBCT with very high HU values."""
 
@@ -1361,6 +1396,7 @@ class Katy1(CatPhan504Mixin, TestCase):
     slice_thickness = 2.4
 
 
+@pytest.mark.proprietary
 class CTWithCloseCouch(CatPhan503Mixin, TestCase):
     """A CT where the couch is super close"""
 
@@ -1382,6 +1418,7 @@ class CTWithCloseCouch(CatPhan503Mixin, TestCase):
     slice_thickness = 1.42
 
 
+@pytest.mark.proprietary
 class AGElekta1(CatPhan503Mixin, TestCase):
     """An Elekta CBCT dataset"""
 
@@ -1403,6 +1440,7 @@ class AGElekta1(CatPhan503Mixin, TestCase):
     slice_thickness = 1.15
 
 
+@pytest.mark.proprietary
 class AGElekta2(CatPhan503Mixin, TestCase):
     """An Elekta CBCT dataset"""
 
@@ -1424,6 +1462,7 @@ class AGElekta2(CatPhan503Mixin, TestCase):
     slice_thickness = 1
 
 
+@pytest.mark.proprietary
 class Elekta4(CatPhan503Mixin, TestCase):
     """An Elekta CBCT dataset"""
 
@@ -1449,6 +1488,7 @@ class Elekta4(CatPhan503Mixin, TestCase):
     slice_thickness = 1
 
 
+@pytest.mark.proprietary
 class Elekta7(CatPhan503Mixin, TestCase):
     """An Elekta CBCT dataset"""
 
@@ -1468,6 +1508,7 @@ class Elekta7(CatPhan503Mixin, TestCase):
     slice_thickness = 1
 
 
+@pytest.mark.proprietary
 class Elekta8(CatPhan503Mixin, TestCase):
     """An Elekta CBCT dataset"""
 
@@ -1493,6 +1534,7 @@ class Elekta8(CatPhan503Mixin, TestCase):
     slice_thickness = 1
 
 
+@pytest.mark.proprietary
 class UNC100kV(CatPhan503Mixin, TestCase):
     file_name = "UNC-100kV_CBCT_Feb2016.zip"
     origin_slice = 131
@@ -1510,6 +1552,7 @@ class UNC100kV(CatPhan503Mixin, TestCase):
     slice_thickness = 1.4
 
 
+@pytest.mark.proprietary
 class UNC120kV(CatPhan503Mixin, TestCase):
     file_name = "UNC-120kV_CBCT_Feb2016.zip"
     origin_slice = 131
@@ -1533,6 +1576,7 @@ class UNC120kV(CatPhan503Mixin, TestCase):
     slice_thickness = 1.5
 
 
+@pytest.mark.proprietary
 class CatPhan600_1(CatPhan600Mixin, TestCase):
     file_name = "zzCAT201601.zip"
     expected_roll = -1.1
@@ -1556,6 +1600,7 @@ class CatPhan600_1(CatPhan600Mixin, TestCase):
         self.assertNotIn("Vial", self.cbct.ctp404.rois)
 
 
+@pytest.mark.proprietary
 class TOHPhilips2mm(CatPhan504Mixin, TestCase):
     file_name = "H TOH - Philips120kV2mm.zip"
     expected_roll = -0.2
@@ -1575,6 +1620,7 @@ class TOHPhilips2mm(CatPhan504Mixin, TestCase):
     lowcon_visible = 6
 
 
+@pytest.mark.proprietary
 class DBCatPhan503Roll(CatPhan503Mixin, TestCase):
     file_name = "DenisBrojan-Catphan503_MFOV_resolution_problem.zip"
     expected_roll = -0.12
@@ -1659,6 +1705,7 @@ class CatPhan604Sen(CatPhan604Mixin, TestCase):
     lowcon_visible = 2
 
 
+@pytest.mark.proprietary
 @mark.catphan604
 class CatPhan604Som(CatPhan604Mixin, TestCase):
     file_name = "SiemensSomCatPhan604.zip"
@@ -1680,6 +1727,7 @@ class CatPhan604Som(CatPhan604Mixin, TestCase):
     slice_thickness = 1
 
 
+@pytest.mark.proprietary
 @mark.catphan604
 class CatPhan604wJig(CatPhan604Mixin, TestCase):
     file_name = "Catphan604-with-jig.zip"
@@ -1702,6 +1750,7 @@ class CatPhan604wJig(CatPhan604Mixin, TestCase):
     avg_noise_power = 0.287
 
 
+@pytest.mark.proprietary
 @mark.catphan604
 class CatPhan604wJig2(CatPhan604Mixin, TestCase):
     file_name = "Catphan604wJig2.zip"
@@ -1725,6 +1774,7 @@ class CatPhan604wJig2(CatPhan604Mixin, TestCase):
     lowcon_visible = 2
 
 
+@pytest.mark.proprietary
 class CatPhan604SiemensDirectDensity(CatPhan604Mixin, TestCase):
     # the direct density algorithm will skew teflon to be ~400 HU. This will cause an HU-found error
     # lowering the HU origin variance will resolve this.
@@ -1752,6 +1802,7 @@ class CatPhan604SiemensDirectDensity(CatPhan604Mixin, TestCase):
     lowcon_visible = 1
 
 
+@pytest.mark.proprietary
 class CatPhan503SliceOverlap(CatPhan503Mixin, TestCase):
     """This dataset is 6mm slices with a 2mm overlap. The slice thickness
     default algorithm gives incorrect values unless the straddle is set explicitly"""
@@ -1774,6 +1825,7 @@ class CatPhan503SliceOverlap(CatPhan503Mixin, TestCase):
     mtf_values = {50: 0.40}
 
 
+@pytest.mark.proprietary
 @mark.catphan604
 class CatPhan604NegativeSliceOverlap(CatPhan604Mixin, TestCase):
     """Has a negative value for slice overlap. Has to do with stack order, but is irrelevant for our needs:
@@ -1800,6 +1852,7 @@ class CatPhan604NegativeSliceOverlap(CatPhan604Mixin, TestCase):
     lowcon_visible = 6
 
 
+@pytest.mark.proprietary
 @mark.catphan604
 class CatPhan604WireLocalization(CatPhan604Mixin, TestCase):
     """Caused detection issues due to the wire not being present in some slices
@@ -1827,6 +1880,7 @@ class CatPhan604WireLocalization(CatPhan604Mixin, TestCase):
     lowcon_visible = 2
 
 
+@pytest.mark.proprietary
 @mark.catphan604
 class CatPhan604CoCr(CatPhan604Mixin, TestCase):
     """Caused detection issues due to the wire not being present in some slices
@@ -1854,6 +1908,7 @@ class CatPhan604CoCr(CatPhan604Mixin, TestCase):
     lowcon_visible = 2
 
 
+@pytest.mark.proprietary
 @mark.directdensity
 @mark.catphan604
 class CatPhan604SliceRefinementLocalization(CatPhan604Mixin, TestCase):
@@ -1882,6 +1937,7 @@ class CatPhan604SliceRefinementLocalization(CatPhan604Mixin, TestCase):
     lowcon_visible = 6
 
 
+@pytest.mark.proprietary
 @mark.directdensity
 @mark.catphan604
 class CatPhan604DD2(CatPhan604Mixin, TestCase):
@@ -1908,6 +1964,7 @@ class CatPhan604DD2(CatPhan604Mixin, TestCase):
     lowcon_visible = 6
 
 
+@pytest.mark.proprietary
 @mark.directdensity
 @mark.catphan604
 class CatPhan604DD3(CatPhan604Mixin, TestCase):
@@ -1934,6 +1991,7 @@ class CatPhan604DD3(CatPhan604Mixin, TestCase):
     lowcon_visible = 6
 
 
+@pytest.mark.proprietary
 class CatPhan504NearEdge(CatPhan504Mixin, TestCase):
     file_name = "phantom_edge.zip"
     expected_roll = 1.4

--- a/tests_basic/test_cheese.py
+++ b/tests_basic/test_cheese.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import pytest
 import math
 from unittest import TestCase
 
@@ -21,6 +22,7 @@ from tests_basic.utils import (
 TEST_DIR = "Tomo"
 
 
+@pytest.mark.proprietary
 class TestInstantiation(
     TestCase,
     InitTesterMixin,
@@ -177,6 +179,7 @@ class TestTomoQuaac(QuaacTestBase, TestCase):
         return t
 
 
+@pytest.mark.proprietary
 class TestCIRS062Quaac(QuaacTestBase, CloudFileMixin, TestCase):
     dir_path = ["Tomo", "CIRS062M"]
     file_name = "CIRS062M - Erogluer.zip"
@@ -277,6 +280,7 @@ class TestTomoCheeseDemo(CheeseMixin, PlotlyTestMixin, TestCase):
         cls.cheese.analyze()
 
 
+@pytest.mark.proprietary
 class TestHighHURodTomo(CheeseMixin, TestCase):
     dir_path = ["Tomo"]
     file_name = "High HU rod tomo.zip"
@@ -290,6 +294,7 @@ class TestHighHURodTomo(CheeseMixin, TestCase):
     }
 
 
+@pytest.mark.proprietary
 class TestCIRS062MErogluer(CheeseMixin, TestCase):
     model = CIRS062M
     origin_slice = 32
@@ -317,6 +322,7 @@ class TestCIRS062MErogluer(CheeseMixin, TestCase):
     }
 
 
+@pytest.mark.proprietary
 class TestCIRS062MButsonCareDose(CheeseMixin, TestCase):
     model = CIRS062M
     origin_slice = 38
@@ -344,6 +350,7 @@ class TestCIRS062MButsonCareDose(CheeseMixin, TestCase):
     }
 
 
+@pytest.mark.proprietary
 class TestCIRS062MButson160mAsB(CheeseMixin, TestCase):
     # same as caredose but different mAs, thus same HU values
     model = CIRS062M
@@ -372,6 +379,7 @@ class TestCIRS062MButson160mAsB(CheeseMixin, TestCase):
     }
 
 
+@pytest.mark.proprietary
 class TestCIRS062MButsonLungOuter(CheeseMixin, TestCase):
     model = CIRS062M
     origin_slice = 24
@@ -399,6 +407,7 @@ class TestCIRS062MButsonLungOuter(CheeseMixin, TestCase):
     }
 
 
+@pytest.mark.proprietary
 class TestCIRS062MButsonEmptyButoOuter(CheeseMixin, TestCase):
     model = CIRS062M
     origin_slice = 30
@@ -426,6 +435,7 @@ class TestCIRS062MButsonEmptyButoOuter(CheeseMixin, TestCase):
     }
 
 
+@pytest.mark.proprietary
 class TestCIRS062MShifted(CheeseMixin, TestCase):
     model = CIRS062M
     origin_slice = 30
@@ -439,6 +449,7 @@ class TestCIRS062MShifted(CheeseMixin, TestCase):
     }
 
 
+@pytest.mark.proprietary
 class TestCIRS062MApplyShifts(CheeseMixin, TestCase):
     # we apply some crazy shifts that will cause the ROIs to be off but also border
     # the ROI edges. This should make testing constancy robust since any small change

--- a/tests_basic/test_dlg.py
+++ b/tests_basic/test_dlg.py
@@ -1,3 +1,4 @@
+import pytest
 import unittest
 
 from pylinac.dlg import DLG
@@ -5,8 +6,11 @@ from pylinac.picketfence import MLC
 from tests_basic.utils import get_file_from_cloud_test_repo
 
 
+@pytest.mark.proprietary
 class TestDLG(unittest.TestCase):
-    file_path = get_file_from_cloud_test_repo(["DLG_1.5_0.2.dcm"])
+    @classmethod
+    def setUpClass(cls):
+        cls.file_path = get_file_from_cloud_test_repo(["DLG_1.5_0.2.dcm"])
 
     def test_measured_dlg(self):
         dlg = DLG(self.file_path)

--- a/tests_basic/test_field_analysis.py
+++ b/tests_basic/test_field_analysis.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import os.path as osp
+import pytest
 import tempfile
 from unittest import TestCase
 
@@ -51,6 +52,7 @@ class FieldAnalysisTests(QuaacTestBase, TestCase):
     def quaac_instance(self):
         return create_instance()
 
+    @pytest.mark.proprietary
     def test_load_from_file_object(self):
         path = get_file_from_cloud_test_repo([TEST_DIR, "6x-auto-bulb-2.dcm"])
         ref_fa = FieldAnalysis(path)
@@ -61,6 +63,7 @@ class FieldAnalysisTests(QuaacTestBase, TestCase):
         self.assertIsInstance(fa, FieldAnalysis)
         self.assertEqual(fa.image.shape, ref_fa.image.shape)
 
+    @pytest.mark.proprietary
     def test_load_from_stream(self):
         path = get_file_from_cloud_test_repo([TEST_DIR, "6x-auto-bulb-2.dcm"])
         ref_fa = FieldAnalysis(path)
@@ -229,6 +232,7 @@ class FieldAnalysisTests(QuaacTestBase, TestCase):
         with self.assertRaises(ValueError):
             fa.analyze(interpolation="limmerick")
 
+    @pytest.mark.proprietary
     def test_image_kwargs(self):
         path = get_file_from_cloud_test_repo([TEST_DIR, "6x-auto-bulb-2.dcm"])
 
@@ -432,6 +436,7 @@ class FieldAnalysisBase(CloudFileMixin):
         self.assertIsInstance(figs[0], plt.Figure)
 
 
+@pytest.mark.proprietary
 class NormalOpenField(FieldAnalysisBase, TestCase):
     """Typical field w/ horns"""
 
@@ -453,6 +458,7 @@ class NormalOpenField(FieldAnalysisBase, TestCase):
     penum_left = 3.3
 
 
+@pytest.mark.proprietary
 class PerfectOpenField(FieldAnalysisBase, TestCase):
     """Completely flat field"""
 
@@ -474,6 +480,7 @@ class PerfectOpenField(FieldAnalysisBase, TestCase):
     penum_left = 3.3
 
 
+@pytest.mark.proprietary
 class FFFOpenField(FieldAnalysisBase, TestCase):
     """FFF field. Note the same field size and penumbra as a flat beam"""
 
@@ -495,6 +502,7 @@ class FFFOpenField(FieldAnalysisBase, TestCase):
     penum_left = 3.3
 
 
+@pytest.mark.proprietary
 class FFFOpenFieldHill(FFFOpenField, TestCase):
     """FFF field using Hill inflection. Note all values are the same. I.e. analysis is equivalent"""
 
@@ -531,6 +539,7 @@ class FlatSymWideDemo(FlatSymDemo, TestCase):
     vert_symmetry = -2.7
 
 
+@pytest.mark.proprietary
 class FlatSym6X(FieldAnalysisBase, TestCase):
     file_name = "6x-auto-bulb-2.dcm"
     # independently verified
@@ -552,6 +561,7 @@ class FlatSym6X(FieldAnalysisBase, TestCase):
     penum_left = 2.8
 
 
+@pytest.mark.proprietary
 class FlatSym18X(FieldAnalysisBase, TestCase):
     file_name = "18x-auto-bulb2.dcm"
     # independently verified
@@ -573,12 +583,14 @@ class FlatSym18X(FieldAnalysisBase, TestCase):
     penum_left = 3.4
 
 
+@pytest.mark.proprietary
 class FlatSym18xSiemens(FlatSym18X):
     protocol = Protocol.SIEMENS
     horiz_symmetry = -0.33
     vert_symmetry = -0.27
 
 
+@pytest.mark.proprietary
 class FlatSym18xSiemens2(FlatSym18xSiemens):
     interpolation_resolution = (
         0.137  # use an arbitrary interpolation so that we get an odd number of points
@@ -587,6 +599,7 @@ class FlatSym18xSiemens2(FlatSym18xSiemens):
     penum_left = 2.9
 
 
+@pytest.mark.proprietary
 class FlatSym18xSiementsNoInterp(FlatSym18xSiemens):
     interpolation_method = Interpolation.NONE
     horiz_symmetry = -0.62
@@ -594,6 +607,7 @@ class FlatSym18xSiementsNoInterp(FlatSym18xSiemens):
     penum_left = 3.0
 
 
+@pytest.mark.proprietary
 class BBLike(FieldAnalysisBase, TestCase):
     """BB-like image"""
 

--- a/tests_basic/test_field_profile_analysis.py
+++ b/tests_basic/test_field_profile_analysis.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 import os.path as osp
+import pytest
 from dataclasses import dataclass
 from unittest import TestCase
 
@@ -248,6 +249,7 @@ class FieldAnalysisTests(TestCase):
     def tearDown(self) -> None:
         plt.close("all")
 
+    @pytest.mark.proprietary
     def test_load_from_file_object(self):
         path = get_file_from_cloud_test_repo([TEST_DIR, "6x-auto-bulb-2.dcm"])
         ref_fa = FieldProfileAnalysis(path)
@@ -258,6 +260,7 @@ class FieldAnalysisTests(TestCase):
         self.assertIsInstance(fa, FieldProfileAnalysis)
         self.assertEqual(fa.image.shape, ref_fa.image.shape)
 
+    @pytest.mark.proprietary
     def test_load_from_stream(self):
         path = get_file_from_cloud_test_repo([TEST_DIR, "6x-auto-bulb-2.dcm"])
         ref_fa = FieldProfileAnalysis(path)
@@ -371,6 +374,7 @@ class FieldAnalysisTests(TestCase):
         with self.assertRaises(ValueError):
             fa.analyze(normalization="limmerick")
 
+    @pytest.mark.proprietary
     def test_image_kwargs(self):
         path = get_file_from_cloud_test_repo([TEST_DIR, "6x-auto-bulb-2.dcm"])
 
@@ -430,6 +434,7 @@ class FlatSymWideDemo(FlatSymDemo, TestCase):
     width = 0.1
 
 
+@pytest.mark.proprietary
 class NormalOpenField(FieldProfileAnalysisPlusV1Comparison, TestCase):
     """Typical field w/ horns"""
 
@@ -459,6 +464,7 @@ class NormalOpenField(FieldProfileAnalysisPlusV1Comparison, TestCase):
     ]
 
 
+@pytest.mark.proprietary
 class PerfectOpenField(FieldProfileAnalysisPlusV1Comparison, TestCase):
     """Completely flat field"""
 
@@ -494,6 +500,7 @@ class PerfectOpenField(FieldProfileAnalysisPlusV1Comparison, TestCase):
     ]
 
 
+@pytest.mark.proprietary
 class FFFOpenField(FieldProfileAnalysisPlusV1Comparison, TestCase):
     """FFF field. Note the same field size and penumbra as a flat beam"""
 
@@ -523,6 +530,7 @@ class FFFOpenField(FieldProfileAnalysisPlusV1Comparison, TestCase):
     ]
 
 
+@pytest.mark.proprietary
 class FFFOpenFieldHill(FFFOpenField, TestCase):
     """FFF field using Hill inflection. All metrics are the same except the y symmetry.
     This is because of an extra pixel (due to rounding) being included. The worst symmetry
@@ -555,6 +563,7 @@ class FFFOpenFieldHill(FFFOpenField, TestCase):
     ]
 
 
+@pytest.mark.proprietary
 class FlatSym6X(FieldProfileAnalysisPlusV1Comparison, TestCase):
     file_name = "6x-auto-bulb-2.dcm"
     x_field_size = 99.4
@@ -587,6 +596,7 @@ class FlatSym6X(FieldProfileAnalysisPlusV1Comparison, TestCase):
     ]
 
 
+@pytest.mark.proprietary
 class FlatSym18X(FieldProfileAnalysisPlusV1Comparison, TestCase):
     file_name = "18x-auto-bulb2.dcm"
     x_field_size = 99.4

--- a/tests_basic/test_nuclear.py
+++ b/tests_basic/test_nuclear.py
@@ -1,4 +1,5 @@
 import json
+import pytest
 from pathlib import Path
 from unittest import TestCase
 
@@ -27,6 +28,9 @@ from pylinac.nuclear import (
 )
 from tests_basic.core.test_utilities import QuaacTestBase
 from tests_basic.utils import get_file_from_cloud_test_repo
+
+pytestmark = pytest.mark.proprietary
+
 
 TEST_DIR = Path("nuclear")
 

--- a/tests_basic/test_picketfence.py
+++ b/tests_basic/test_picketfence.py
@@ -2,6 +2,7 @@ import io
 import json
 import os
 import os.path as osp
+import pytest
 import statistics
 import tempfile
 from itertools import chain
@@ -37,6 +38,7 @@ from tests_basic.utils import (
 TEST_DIR = "picket_fence"
 
 
+@pytest.mark.proprietary
 class TestInstantiation(
     TestCase, InitTesterMixin, FromURLTesterMixin, FromDemoImageTesterMixin
 ):
@@ -193,6 +195,7 @@ class TestAnalyze(TestCase):
         data = self.pf.results_data()
         self.assertEqual(len(data.warnings), 0)
 
+    @pytest.mark.proprietary
     def test_no_measurements_suggests_inversion(self):
         file_loc = get_file_from_cloud_test_repo(
             [TEST_DIR, "noisy-FFF-wide-gap-pf.dcm"]
@@ -322,6 +325,7 @@ class TestAnalyze(TestCase):
 
 
 class TestBBBasedAnalysis(TestCase):
+    @pytest.mark.proprietary
     def test_two_different_image_sizes(self):
         # See RAM-3258
         # load both images
@@ -370,6 +374,7 @@ class TestBBBasedAnalysis(TestCase):
         self.assertAlmostEqual(results.mlc_positions_by_leaf["17"][0], 102, delta=0.1)
 
 
+@pytest.mark.proprietary
 class LoadingFromMultiple(TestCase):
     def test_loading_with_keywords(self):
         # we pass **kwargs to the PFDicomImage constructor and also the PicketFence constructor
@@ -588,6 +593,7 @@ class PFTestMixin(CloudFileMixin):
             self.assertEqual(self.max_error_leaf, self.pf.max_error_leaf)
 
 
+@pytest.mark.proprietary
 class PFDemo(PFTestMixin, TestCase):
     """Tests specifically for the EPID demo image."""
 
@@ -613,6 +619,7 @@ class PFDemo(PFTestMixin, TestCase):
         self.assertAlmostEqual(pf.percent_passing, 100, delta=1)
 
 
+@pytest.mark.proprietary
 class PerfectSimulation(PFTestMixin, TestCase):
     file_name = "perfect-pf.dcm"
     max_error = 0
@@ -622,6 +629,7 @@ class PerfectSimulation(PFTestMixin, TestCase):
     crop_mm = 0
 
 
+@pytest.mark.proprietary
 class Rotated2Simulation(PFTestMixin, TestCase):
     file_name = "perfect-pf.dcm"
     max_error = 0
@@ -645,6 +653,7 @@ class Rotated2Simulation(PFTestMixin, TestCase):
         )
 
 
+@pytest.mark.proprietary
 class RotatedMinus2Simulation(PFTestMixin, TestCase):
     file_name = "perfect-pf.dcm"
     max_error = 0
@@ -668,6 +677,7 @@ class RotatedMinus2Simulation(PFTestMixin, TestCase):
         )
 
 
+@pytest.mark.proprietary
 class WideGapSimulation(PFTestMixin, TestCase):
     file_name = "noisy-wide-gap-pf.dcm"
     max_error = 0.11
@@ -684,6 +694,7 @@ class WideGapSimulationSeparate(WideGapSimulation):
     percent_passing = 100
 
 
+@pytest.mark.proprietary
 class FFFWideGapSimulation(PFTestMixin, TestCase):
     file_name = "noisy-FFF-wide-gap-pf.dcm"
     max_error = 0.17
@@ -692,6 +703,7 @@ class FFFWideGapSimulation(PFTestMixin, TestCase):
     mean_picket_spacing = 30
 
 
+@pytest.mark.proprietary
 class AS1200(PFTestMixin, TestCase):
     """Tests for the AS1200 image."""
 
@@ -700,6 +712,7 @@ class AS1200(PFTestMixin, TestCase):
     abs_median_error = 0.02
 
 
+@pytest.mark.proprietary
 class ClinacWeirdBackground(PFTestMixin, TestCase):
     file_name = "Clinac-weird-background.dcm"
     max_error = 0.12
@@ -709,6 +722,7 @@ class ClinacWeirdBackground(PFTestMixin, TestCase):
     invert = True
 
 
+@pytest.mark.proprietary
 class ElektaCloseEdges(PFTestMixin, TestCase):
     file_name = "PF,-Elekta,-pickets-near-edges.dcm"
     max_error = 0.23
@@ -718,6 +732,7 @@ class ElektaCloseEdges(PFTestMixin, TestCase):
     mlc_skew = -0.7
 
 
+@pytest.mark.proprietary
 class ElektaCloseEdgesRot90(PFTestMixin, TestCase):
     file_name = "PF,-Elekta,-pickets-near-edges.dcm"
     max_error = 0.23
@@ -734,6 +749,7 @@ class ElektaCloseEdgesRot90(PFTestMixin, TestCase):
         cls.pf.analyze(sag_adjustment=cls.sag_adjustment)
 
 
+@pytest.mark.proprietary
 class MultipleImagesPF(PFTestMixin, TestCase):
     """Test of a multiple image picket fence; e.g. EPID images."""
 
@@ -754,6 +770,7 @@ class MultipleImagesPF(PFTestMixin, TestCase):
         )
 
 
+@pytest.mark.proprietary
 class MultipleImagesPF2(PFTestMixin, TestCase):
     """Test of a multiple image picket fence; e.g. EPID images."""
 
@@ -774,6 +791,7 @@ class MultipleImagesPF2(PFTestMixin, TestCase):
         )
 
 
+@pytest.mark.proprietary
 class AS500(PFTestMixin, TestCase):
     """Tests for the AS500 image."""
 
@@ -782,6 +800,7 @@ class AS500(PFTestMixin, TestCase):
     abs_median_error = 0.04
 
 
+@pytest.mark.proprietary
 class AS5002(PFTestMixin, TestCase, PlotlyTestMixin):
     """Tests for the AS500#2 image."""
 
@@ -817,6 +836,7 @@ class AS5002(PFTestMixin, TestCase, PlotlyTestMixin):
         return cls
 
 
+@pytest.mark.proprietary
 class AS5003(PFTestMixin, TestCase):
     """Tests for the AS500#3 image."""
 
@@ -825,6 +845,7 @@ class AS5003(PFTestMixin, TestCase):
     abs_median_error = 0.03
 
 
+@pytest.mark.proprietary
 class AS5004(PFTestMixin, TestCase):
     """Tests for the AS500#4 image."""
 
@@ -834,6 +855,7 @@ class AS5004(PFTestMixin, TestCase):
     mlc_skew = -0.3
 
 
+@pytest.mark.proprietary
 class AS5005(PFTestMixin, TestCase):
     """Tests for the AS500#4 image."""
 
@@ -842,6 +864,7 @@ class AS5005(PFTestMixin, TestCase):
     abs_median_error = 0.04
 
 
+@pytest.mark.proprietary
 class AS5006(PFTestMixin, TestCase):
     """Tests for the AS500#4 image."""
 
@@ -851,6 +874,7 @@ class AS5006(PFTestMixin, TestCase):
     abs_median_error = 0.06
 
 
+@pytest.mark.proprietary
 class AS5007(PFTestMixin, TestCase):
     """Tests for the AS500#4 image."""
 
@@ -860,6 +884,7 @@ class AS5007(PFTestMixin, TestCase):
     mlc_skew = -0.3
 
 
+@pytest.mark.proprietary
 class AS5008(PFTestMixin, TestCase):
     """Tests for the AS500#4 image."""
 
@@ -869,6 +894,7 @@ class AS5008(PFTestMixin, TestCase):
     mlc_skew = -0.3
 
 
+@pytest.mark.proprietary
 class AS5009(PFTestMixin, TestCase):
     """Tests for the AS500#4 image."""
 
@@ -878,6 +904,7 @@ class AS5009(PFTestMixin, TestCase):
     mlc_skew = -0.3
 
 
+@pytest.mark.proprietary
 class AS50010(PFTestMixin, TestCase):
     """Tests for the AS500#4 image."""
 
@@ -887,6 +914,7 @@ class AS50010(PFTestMixin, TestCase):
     abs_median_error = 0.05
 
 
+@pytest.mark.proprietary
 class AS500error(PFTestMixin, TestCase):
     """Tests for the AS500#2 image."""
 
@@ -900,6 +928,7 @@ class AS500error(PFTestMixin, TestCase):
     mlc_skew = -0.3
 
 
+@pytest.mark.proprietary
 class AS1000(PFTestMixin, TestCase):
     """Tests for the AS1000 image."""
 
@@ -908,6 +937,7 @@ class AS1000(PFTestMixin, TestCase):
     abs_median_error = 0.06
 
 
+@pytest.mark.proprietary
 class AS1000_2(PFTestMixin, TestCase):
     """Tests for the AS1000 image."""
 
@@ -916,6 +946,7 @@ class AS1000_2(PFTestMixin, TestCase):
     abs_median_error = 0.07
 
 
+@pytest.mark.proprietary
 class AS1000_3(PFTestMixin, TestCase):
     """Tests for the AS1000 image."""
 
@@ -924,6 +955,7 @@ class AS1000_3(PFTestMixin, TestCase):
     abs_median_error = 0.05
 
 
+@pytest.mark.proprietary
 class AS1000_4(PFTestMixin, TestCase):
     """Tests for the AS1000 image."""
 
@@ -933,6 +965,7 @@ class AS1000_4(PFTestMixin, TestCase):
     abs_median_error = 0.05
 
 
+@pytest.mark.proprietary
 class AS1000_90(PFTestMixin, TestCase):
     """Tests for the AS1000 image."""
 
@@ -942,6 +975,7 @@ class AS1000_90(PFTestMixin, TestCase):
     abs_median_error = 0.05
 
 
+@pytest.mark.proprietary
 class AS1000HDSmall(PFTestMixin, TestCase):
     """Tests for the AS1000 image."""
 
@@ -951,6 +985,7 @@ class AS1000HDSmall(PFTestMixin, TestCase):
     abs_median_error = 0.05
 
 
+@pytest.mark.proprietary
 class AS1000HDFull(PFTestMixin, TestCase):
     """Tests for the AS1000 image with a smaller pattern (only inner leaves)."""
 
@@ -960,6 +995,7 @@ class AS1000HDFull(PFTestMixin, TestCase):
     abs_median_error = 0.06
 
 
+@pytest.mark.proprietary
 class AS1000HDFullVMAT(PFTestMixin, TestCase):
     """Tests for the AS1000 image with a smaller pattern (only inner leaves)."""
 
@@ -986,6 +1022,7 @@ class AS1000HDFullError(PFTestMixin, TestCase):
         self.assertFalse(pf.passed)
 
 
+@pytest.mark.proprietary
 class AS1200Error(PFTestMixin, TestCase):
     """Tests for the AS1200 image."""
 
@@ -997,6 +1034,7 @@ class AS1200Error(PFTestMixin, TestCase):
     mean_picket_spacing = 20
 
 
+@pytest.mark.proprietary
 class AS1200ExtendedSID(PFTestMixin, TestCase):
     """Tests for the AS1200 image."""
 
@@ -1005,6 +1043,7 @@ class AS1200ExtendedSID(PFTestMixin, TestCase):
     abs_median_error = 0.04
 
 
+@pytest.mark.proprietary
 class AS1200ExtendedSIDVMAT(PFTestMixin, TestCase):
     """Tests for the AS1200 image."""
 
@@ -1035,6 +1074,7 @@ class AS1200ExtendedSIDVMAT(PFTestMixin, TestCase):
 #     pass_num_pickets = True
 
 
+@pytest.mark.proprietary
 class ChicagoNoError(PFTestMixin, TestCase):
     dir_path = [TEST_DIR, "Chicago"]
     file_name = "PF no error.dcm"
@@ -1043,6 +1083,7 @@ class ChicagoNoError(PFTestMixin, TestCase):
     max_error = 0.3
 
 
+@pytest.mark.proprietary
 class ChicagoError(PFTestMixin, TestCase):
     dir_path = [TEST_DIR, "Chicago"]
     file_name = "PF point2mm error.dcm"
@@ -1051,6 +1092,7 @@ class ChicagoError(PFTestMixin, TestCase):
     max_error = 0.3
 
 
+@pytest.mark.proprietary
 class HalcyonProximal(PFTestMixin, TestCase):
     file_name = "Distal - DoRa - Really proximal.dcm"
     mlc = "Halcyon proximal"
@@ -1059,6 +1101,7 @@ class HalcyonProximal(PFTestMixin, TestCase):
     mean_picket_spacing = 50
 
 
+@pytest.mark.proprietary
 class HalcyonDistal(PFTestMixin, TestCase):
     file_name = "Proximal - DoRa - Really distal.dcm"
     mlc = "Halcyon distal"
@@ -1079,6 +1122,7 @@ class CharlestonG0(PFTestMixin, TestCase):
     max_error = 0.1
 
 
+@pytest.mark.proprietary
 class CanberraShortSet(PFTestMixin, TestCase):
     """This is a small picket set (~10-20 leaves). Should be no problem"""
 

--- a/tests_basic/test_planar_imaging.py
+++ b/tests_basic/test_planar_imaging.py
@@ -1,6 +1,7 @@
 import io
 import json
 import os.path as osp
+import pytest
 from typing import Callable
 from unittest import TestCase, skip
 
@@ -63,6 +64,7 @@ class TestPercentIntegralUniformity(TestCase):
 
 
 class GeneralTests(TestCase):
+    @pytest.mark.proprietary
     def test_from_file_object(self):
         path = get_file_from_cloud_test_repo([TEST_DIR, "Leeds", "Leeds_ccw.dcm"])
         with open(path, "rb") as f:
@@ -70,6 +72,7 @@ class GeneralTests(TestCase):
             phan.analyze()
         self.assertIsInstance(phan, LeedsTOR)
 
+    @pytest.mark.proprietary
     def test_from_stream(self):
         path = get_file_from_cloud_test_repo([TEST_DIR, "Leeds", "Leeds_ccw.dcm"])
         with open(path, "rb") as f:
@@ -177,6 +180,7 @@ class GeneralTests(TestCase):
         with self.assertRaises(ValueError):
             phan.save_analyzed_image()  # no filename and no streams is an error
 
+    @pytest.mark.proprietary
     def test_passing_image_kwargs(self):
         path = get_file_from_cloud_test_repo([TEST_DIR, "Leeds", "Leeds_ccw.dcm"])
 
@@ -332,12 +336,14 @@ class LeedsDemo(LeedsMixin, TestCase):
         LeedsTOR.run_demo()  # shouldn't raise
 
 
+@pytest.mark.proprietary
 class LeedsCCW(LeedsMixin, TestCase):
     mtf_50 = 1.5
     file_name = "Leeds_ccw.dcm"
     piu = 93.5
 
 
+@pytest.mark.proprietary
 class Leeds45Deg(LeedsMixin, TestCase):
     mtf_50 = 1.9
     ssd = "auto"
@@ -345,6 +351,7 @@ class Leeds45Deg(LeedsMixin, TestCase):
     piu = 95.5
 
 
+@pytest.mark.proprietary
 class LeedsDirtyEdges(LeedsMixin, TestCase):
     mtf_50 = 1.53
     ssd = "auto"
@@ -352,6 +359,7 @@ class LeedsDirtyEdges(LeedsMixin, TestCase):
     piu = 96.8
 
 
+@pytest.mark.proprietary
 class LeedsOffsetHighRes(LeedsMixin, TestCase):
     mtf_50 = 1.85
     ssd = "auto"
@@ -359,6 +367,7 @@ class LeedsOffsetHighRes(LeedsMixin, TestCase):
     piu = 89.3
 
 
+@pytest.mark.proprietary
 class LeedsBlue(LeedsMixin, TestCase):
     klass = LeedsTORBlue
     mtf_50 = 1.5
@@ -368,6 +377,7 @@ class LeedsBlue(LeedsMixin, TestCase):
     fig_data = {0: {"title": "Leeds (Blue) Phantom Analysis", "num_traces": 36}}
 
 
+@pytest.mark.proprietary
 class LeedsBlueRotated(LeedsMixin, TestCase):
     klass = LeedsTORBlue
     mtf_50 = 1.5
@@ -415,6 +425,7 @@ class SIQC3Demo(PlanarPhantomMixin, TestCase):
         StandardImagingQC3.run_demo()  # shouldn't raise
 
 
+@pytest.mark.proprietary
 class SIQC3_1(PlanarPhantomMixin, TestCase):
     klass = StandardImagingQC3
     file_name = "QC3-2.5MV.dcm"
@@ -423,6 +434,7 @@ class SIQC3_1(PlanarPhantomMixin, TestCase):
     piu = 91.8
 
 
+@pytest.mark.proprietary
 class SIQC3_2(PlanarPhantomMixin, TestCase):
     klass = StandardImagingQC3
     file_name = "QC3-2.5MV-2.dcm"
@@ -625,12 +637,14 @@ class ElektaDemo(ElektaLasVegasMixin, TestCase):
         ElektaLasVegas.run_demo()  # shouldn't raise
 
 
+@pytest.mark.proprietary
 class Elekta2MU(ElektaLasVegasMixin, TestCase):
     file_name = "LasVegas_2MU.dcm"
     rois_seen = 12
     piu = 99.11
 
 
+@pytest.mark.proprietary
 class Elekta10MU(ElektaLasVegasMixin, TestCase):
     file_name = "LasVegas_10MU.dcm"
     rois_seen = 17
@@ -655,6 +669,7 @@ class DoselabkVDemo(PlanarPhantomMixin, TestCase):
         DoselabMC2kV.run_demo()
 
 
+@pytest.mark.proprietary
 class DoselabkV70kVp(PlanarPhantomMixin, TestCase):
     klass = DoselabMC2kV
     dir_path = ["planar_imaging", "Doselab MC2"]
@@ -685,6 +700,7 @@ class SNCMVDemo(PlanarPhantomMixin, TestCase):
         SNCMV.run_demo()
 
 
+@pytest.mark.proprietary
 class SNCMV12510_6MV1(PlanarPhantomMixin, TestCase):
     klass = SNCMV12510
     mtf_50 = 0.91
@@ -698,6 +714,7 @@ class SNCMV12510_6MV1(PlanarPhantomMixin, TestCase):
         SNCMV12510.run_demo()
 
 
+@pytest.mark.proprietary
 class SNCMV12510_6MV2(PlanarPhantomMixin, TestCase):
     klass = SNCMV12510
     mtf_50 = 0.85
@@ -708,6 +725,7 @@ class SNCMV12510_6MV2(PlanarPhantomMixin, TestCase):
     piu = 96.4
 
 
+@pytest.mark.proprietary
 class SNCMV12510_Jig(PlanarPhantomMixin, TestCase):
     """Phantom where the jig is touching and gets in the way of analysis"""
 
@@ -720,6 +738,7 @@ class SNCMV12510_Jig(PlanarPhantomMixin, TestCase):
     piu = 96.7
 
 
+@pytest.mark.proprietary
 class IBAPrimusDemo(PlanarPhantomMixin, TestCase):
     klass = IBAPrimusA
     dir_path = ["planar_imaging", "PrimusL"]
@@ -734,6 +753,7 @@ class IBAPrimusDemo(PlanarPhantomMixin, TestCase):
         IBAPrimusA.run_demo()
 
 
+@pytest.mark.proprietary
 class IBAPrimusBasic(IBAPrimusDemo):
     # same as demo but no test_demo method; this is inherited so no need to call test_demo a lot
 
@@ -741,6 +761,7 @@ class IBAPrimusBasic(IBAPrimusDemo):
         pass
 
 
+@pytest.mark.proprietary
 class IBAPrimusDemo0(IBAPrimusBasic):
     """Rotate image to 0 (pointing towards gun) to ensure it still analyzes and results are similar"""
 
@@ -749,6 +770,7 @@ class IBAPrimusDemo0(IBAPrimusBasic):
         instance.image.rot90()
 
 
+@pytest.mark.proprietary
 class IBAPrimusShifted(IBAPrimusBasic):
     """Shift the image slightly to ensure we can handle slightly offset phantom placements"""
 
@@ -757,6 +779,7 @@ class IBAPrimusShifted(IBAPrimusBasic):
         instance.image.array = np.roll(instance.image.array, shift=50)
 
 
+@pytest.mark.proprietary
 class IBAPrimusDemoMinus90(IBAPrimusBasic):
     """Rotate image to -90 (pointing left in BEV) to ensure it still analyzes and results are similar"""
 
@@ -765,6 +788,7 @@ class IBAPrimusDemoMinus90(IBAPrimusBasic):
         instance.image.rot90(2)
 
 
+@pytest.mark.proprietary
 class IBAPrimusDemoBadInversion(IBAPrimusBasic):
     """Force a bad inversion and ensure recovery"""
 
@@ -773,6 +797,7 @@ class IBAPrimusDemoBadInversion(IBAPrimusBasic):
         instance.image.invert()
 
 
+@pytest.mark.proprietary
 class IBAPrimusFarSSD(PlanarPhantomMixin, TestCase):
     klass = IBAPrimusA
     dir_path = ["planar_imaging", "PrimusL"]
@@ -803,6 +828,7 @@ class PTWEPIDDemo(PlanarPhantomMixin, TestCase):
         PTWEPIDQC.run_demo()
 
 
+@pytest.mark.proprietary
 class PTWEPIDQC1(PlanarPhantomMixin, TestCase):
     klass = PTWEPIDQC
     mtf_50 = 0.79
@@ -814,6 +840,7 @@ class PTWEPIDQC1(PlanarPhantomMixin, TestCase):
     piu = 94.7
 
 
+@pytest.mark.proprietary
 class PTWEPID15MV(PlanarPhantomMixin, TestCase):
     klass = PTWEPIDQC
     mtf_50 = 0.5
@@ -825,6 +852,7 @@ class PTWEPID15MV(PlanarPhantomMixin, TestCase):
     piu = 96.3
 
 
+@pytest.mark.proprietary
 class PTWEPID6xHigh(PlanarPhantomMixin, TestCase):
     klass = PTWEPIDQC
     mtf_50 = 0.79
@@ -836,6 +864,7 @@ class PTWEPID6xHigh(PlanarPhantomMixin, TestCase):
     piu = 94.3
 
 
+@pytest.mark.proprietary
 class PTWEPID6xHighQuality(PlanarPhantomMixin, TestCase):
     klass = PTWEPIDQC
     mtf_50 = 0.79
@@ -847,6 +876,7 @@ class PTWEPID6xHighQuality(PlanarPhantomMixin, TestCase):
     piu = 94.6
 
 
+@pytest.mark.proprietary
 class PTWEPIDTB3(PlanarPhantomMixin, TestCase):
     klass = PTWEPIDQC
     mtf_50 = 0.79
@@ -858,6 +888,7 @@ class PTWEPIDTB3(PlanarPhantomMixin, TestCase):
     piu = 92.3
 
 
+@pytest.mark.proprietary
 class PTWEPIDTB4(PlanarPhantomMixin, TestCase):
     klass = PTWEPIDQC
     mtf_50 = 0.79
@@ -933,6 +964,7 @@ class FC2Demo(FC2Mixin, TestCase):
         StandardImagingFC2.run_demo()
 
 
+@pytest.mark.proprietary
 class FC210x10_10FFF(FC2Mixin, TestCase):
     file_name = "FC-2-10x10-10fff.dcm"
     field_size_y_mm = 98.7
@@ -943,6 +975,7 @@ class FC210x10_10FFF(FC2Mixin, TestCase):
     field_bb_offset_x_mm = -0.3
 
 
+@pytest.mark.proprietary
 class FC210x10_10X(FC2Mixin, TestCase):
     file_name = "FC-2-10x10-10x.dcm"
     field_size_y_mm = 99.3
@@ -953,6 +986,7 @@ class FC210x10_10X(FC2Mixin, TestCase):
     field_bb_offset_x_mm = -0.1
 
 
+@pytest.mark.proprietary
 class FC210x10_15X(FC2Mixin, TestCase):
     file_name = "FC-2-10x10-15x.dcm"
     field_size_y_mm = 99.3
@@ -963,6 +997,7 @@ class FC210x10_15X(FC2Mixin, TestCase):
     field_bb_offset_x_mm = -0.2
 
 
+@pytest.mark.proprietary
 class FC215x15_10X(FC2Mixin, TestCase):
     file_name = "FC-2-15x15-10X.dcm"
     field_size_x_mm = 149.2
@@ -973,6 +1008,7 @@ class FC215x15_10X(FC2Mixin, TestCase):
     field_bb_offset_x_mm = 0
 
 
+@pytest.mark.proprietary
 class FC215x15_10FFF(FC2Mixin, TestCase):
     file_name = "FC-2-15x15-10XFFF.dcm"
     fwxm = 30
@@ -984,6 +1020,7 @@ class FC215x15_10FFF(FC2Mixin, TestCase):
     field_bb_offset_x_mm = -0.3
 
 
+@pytest.mark.proprietary
 class FC2Yoda(FC2Mixin, TestCase):
     file_name = "FC-2-Yoda.dcm"
     field_size_y_mm = 148.2
@@ -994,6 +1031,7 @@ class FC2Yoda(FC2Mixin, TestCase):
     field_bb_offset_x_mm = 0.5
 
 
+@pytest.mark.proprietary
 class FC2Perfect(FC2Mixin, TestCase):
     file_name = "fc2-perfect.dcm"
     field_size_y_mm = 120.3
@@ -1004,6 +1042,7 @@ class FC2Perfect(FC2Mixin, TestCase):
     field_bb_offset_x_mm = 0
 
 
+@pytest.mark.proprietary
 class FC2FieldDown1mm(FC2Mixin, TestCase):
     file_name = "fc2-down1mm.dcm"
     field_size_y_mm = 120.3
@@ -1014,6 +1053,7 @@ class FC2FieldDown1mm(FC2Mixin, TestCase):
     field_bb_offset_x_mm = 0
 
 
+@pytest.mark.proprietary
 class FC2BBDownRight1mm(FC2Mixin, TestCase):
     file_name = "fc2-bbdownright1mm.dcm"
     field_size_y_mm = 120.3
@@ -1042,6 +1082,7 @@ class DoselabRLfDemo(DoselabRLfMixin, TestCase):
         DoselabRLf.run_demo()
 
 
+@pytest.mark.proprietary
 class DoselabRLf10x10(DoselabRLfMixin, TestCase):
     file_name = "FS 10x10.dcm"
     field_size_y_mm = 98.2
@@ -1052,6 +1093,7 @@ class DoselabRLf10x10(DoselabRLfMixin, TestCase):
     field_bb_offset_x_mm = 0.2
 
 
+@pytest.mark.proprietary
 class DoselabRLfKB(DoselabRLfMixin, TestCase):
     """A failed dataset from KB."""
 
@@ -1064,6 +1106,7 @@ class DoselabRLfKB(DoselabRLfMixin, TestCase):
     field_bb_offset_x_mm = -0.3
 
 
+@pytest.mark.proprietary
 class DoselabRLfKB2(DoselabRLfMixin, TestCase):
     """A failed dataset from KB."""
 
@@ -1110,6 +1153,7 @@ class IMTLRadDemo(IMTLRadMixin, TestCase):
         IMTLRad.run_demo()
 
 
+@pytest.mark.proprietary
 class IMTLRad21x21(IMTLRadMixin, TestCase):
     file_name = "RTIMAGE_11_1.dcm"
     field_size_y_mm = 210.8
@@ -1120,6 +1164,7 @@ class IMTLRad21x21(IMTLRadMixin, TestCase):
     field_bb_offset_x_mm = -0.6
 
 
+@pytest.mark.proprietary
 class IMTLRad21x21_2(IMTLRadMixin, TestCase):
     file_name = "RTIMAGE_11_2.dcm"
     field_size_y_mm = 210.9
@@ -1130,6 +1175,7 @@ class IMTLRad21x21_2(IMTLRadMixin, TestCase):
     field_bb_offset_x_mm = -0.7
 
 
+@pytest.mark.proprietary
 class IMTLRadPerfect(IMTLRadMixin, TestCase):
     file_name = "perfect_imt.dcm"
     field_size_y_mm = 150
@@ -1140,6 +1186,7 @@ class IMTLRadPerfect(IMTLRadMixin, TestCase):
     field_bb_offset_x_mm = 0
 
 
+@pytest.mark.proprietary
 class IMTLRadOffset(IMTLRadMixin, TestCase):
     file_name = "offset_imt.dcm"
     field_size_y_mm = 150
@@ -1168,6 +1215,7 @@ class SNCFSQADemo(SNCFSQAMixin, TestCase):
         SNCFSQA.run_demo()
 
 
+@pytest.mark.proprietary
 class SNCFSQA10x10(SNCFSQAMixin, TestCase):
     file_name = "6x_FSQA_10x10.dcm"
     field_size_y_mm = 99.6

--- a/tests_basic/test_quart.py
+++ b/tests_basic/test_quart.py
@@ -1,6 +1,7 @@
 import io
 import json
 import os
+import pytest
 from pathlib import Path
 from unittest import TestCase
 
@@ -20,6 +21,8 @@ from tests_basic.utils import (
     get_file_from_cloud_test_repo,
     save_file,
 )
+
+pytestmark = pytest.mark.proprietary
 
 TEST_DIR = ["CBCT", "Quart"]
 

--- a/tests_basic/test_starshot.py
+++ b/tests_basic/test_starshot.py
@@ -2,6 +2,7 @@ import io
 import json
 import os
 import os.path as osp
+import pytest
 import tempfile
 from unittest import TestCase
 
@@ -38,6 +39,7 @@ class TestStarshotLoading(TestCase, FromURLTesterMixin):
     url = "starshot.tif"
     kwargs = url_kwargs = {"dpi": 30, "sid": 1000}
 
+    @pytest.mark.proprietary
     def test_load_from_file_object(self):
         with open(
             get_file_from_cloud_test_repo([TEST_DIR, "Starshot-30-deg-perfect.dcm"]),
@@ -47,6 +49,7 @@ class TestStarshotLoading(TestCase, FromURLTesterMixin):
             star.analyze()
         self.assertIsInstance(star, Starshot)
 
+    @pytest.mark.proprietary
     def test_load_from_stream(self):
         with open(
             get_file_from_cloud_test_repo([TEST_DIR, "Starshot-30-deg-perfect.dcm"]),
@@ -239,6 +242,7 @@ class Demo(StarMixin, TestCase):
         return Starshot.from_demo_image()
 
 
+@pytest.mark.proprietary
 class Multiples(StarMixin, TestCase):
     """Test a starshot composed of multiple individual EPID images."""
 
@@ -262,6 +266,7 @@ class Multiples(StarMixin, TestCase):
         star.analyze()
 
 
+@pytest.mark.proprietary
 class Starshot1(StarMixin, PlotlyTestMixin, TestCase):
     file_name = "Starshot-1.tif"
     wobble_center = Point(508, 683)
@@ -276,6 +281,7 @@ class Starshot1(StarMixin, PlotlyTestMixin, TestCase):
         self.instance = self.star
 
 
+@pytest.mark.proprietary
 class StarshotPerfect30Deg(StarMixin, TestCase):
     file_name = "Starshot-30-deg-perfect.dcm"
     wobble_center = Point(639.5, 639.5)
@@ -283,10 +289,12 @@ class StarshotPerfect30Deg(StarMixin, TestCase):
     num_rad_lines = 6
 
 
+@pytest.mark.proprietary
 class Starshot1FWHM(Starshot1):
     fwhm = False
 
 
+@pytest.mark.proprietary
 class CRStarshot(StarMixin, TestCase):
     file_name = "CR-Starshot.dcm"
     wobble_center = Point(1030.5, 1253.6)
@@ -362,6 +370,7 @@ class GeneralTests(Demo, TestCase):
         self.assertEqual(len(data.warnings), 0)
 
 
+@pytest.mark.proprietary
 class Starshot2(StarMixin, TestCase):
     file_name = "Starshot#2.tif"
     wobble_center = Point(566, 590)
@@ -370,6 +379,7 @@ class Starshot2(StarMixin, TestCase):
     # outside: 0.18-0.19
 
 
+@pytest.mark.proprietary
 class Starshot3(StarMixin, TestCase):
     file_name = "Starshot#3.tif"
     wobble_center = Point(466, 595)
@@ -378,6 +388,7 @@ class Starshot3(StarMixin, TestCase):
     # outside 0.33
 
 
+@pytest.mark.proprietary
 class Starshot4(StarMixin, TestCase):
     file_name = "Starshot#4.tif"
     wobble_center = Point(446, 565)
@@ -386,6 +397,7 @@ class Starshot4(StarMixin, TestCase):
     # outside 0.39
 
 
+@pytest.mark.proprietary
 class Starshot5(StarMixin, TestCase):
     file_name = "Starshot#5.tif"
     wobble_center = Point(557, 580)
@@ -396,6 +408,7 @@ class Starshot5(StarMixin, TestCase):
     # outside: 0.14
 
 
+@pytest.mark.proprietary
 class Starshot6(StarMixin, TestCase):
     # for the radii comparison, the wobble at 0.25 is very high due to a bad spoke
     # detection. Setting FWHM to false will fix this. We thus clip the lower radius
@@ -407,6 +420,7 @@ class Starshot6(StarMixin, TestCase):
     radii_range = np.linspace(0.9, 0.3, 8)
 
 
+@pytest.mark.proprietary
 class Starshot7(StarMixin, TestCase):
     file_name = "Starshot#7.tif"
     wobble_center = Point(469, 646)
@@ -415,6 +429,7 @@ class Starshot7(StarMixin, TestCase):
     wobble_tolerance = 0.2
 
 
+@pytest.mark.proprietary
 class Starshot8(StarMixin, TestCase):
     file_name = "Starshot#8.tiff"
     wobble_center = Point(686, 669)
@@ -422,6 +437,7 @@ class Starshot8(StarMixin, TestCase):
     num_rad_lines = 5
 
 
+@pytest.mark.proprietary
 class Starshot9(StarMixin, TestCase):
     file_name = "Starshot#9.tiff"
     wobble_center = Point(714, 611)
@@ -429,6 +445,7 @@ class Starshot9(StarMixin, TestCase):
     num_rad_lines = 5
 
 
+@pytest.mark.proprietary
 class Starshot10(StarMixin, TestCase):
     file_name = "Starshot#10.tiff"
     wobble_center = Point(725, 802)
@@ -436,6 +453,7 @@ class Starshot10(StarMixin, TestCase):
     num_rad_lines = 5
 
 
+@pytest.mark.proprietary
 class Starshot11(StarMixin, TestCase):
     file_name = "Starshot#11.tiff"
     wobble_center = Point(760, 650)
@@ -443,6 +461,7 @@ class Starshot11(StarMixin, TestCase):
     num_rad_lines = 4
 
 
+@pytest.mark.proprietary
 class Starshot12(StarMixin, TestCase):
     file_name = "Starshot#12.tiff"
     wobble_center = Point(315, 292)
@@ -450,6 +469,7 @@ class Starshot12(StarMixin, TestCase):
     num_rad_lines = 4
 
 
+@pytest.mark.proprietary
 class Starshot13(StarMixin, TestCase):
     file_name = "Starshot#13.tiff"
     wobble_center = Point(376, 303)
@@ -457,6 +477,7 @@ class Starshot13(StarMixin, TestCase):
     num_rad_lines = 4
 
 
+@pytest.mark.proprietary
 class Starshot14(StarMixin, TestCase):
     file_name = "Starshot#14.tiff"
     wobble_center = Point(334, 282)
@@ -464,6 +485,7 @@ class Starshot14(StarMixin, TestCase):
     num_rad_lines = 4
 
 
+@pytest.mark.proprietary
 class Starshot15(StarMixin, TestCase):
     file_name = "Starshot#15.tiff"
     wobble_center = Point(346, 309)
@@ -471,6 +493,7 @@ class Starshot15(StarMixin, TestCase):
     num_rad_lines = 4
 
 
+@pytest.mark.proprietary
 class Starshot16(StarMixin, TestCase):
     file_name = "Starshot#16.tiff"
     wobble_center = Point(1444, 1452)
@@ -478,6 +501,7 @@ class Starshot16(StarMixin, TestCase):
     num_rad_lines = 6
 
 
+@pytest.mark.proprietary
 class Starshot17(StarMixin, TestCase):
     file_name = "Starshot#17.tiff"
     wobble_center = Point(1475, 1361)
@@ -485,6 +509,7 @@ class Starshot17(StarMixin, TestCase):
     num_rad_lines = 6
 
 
+@pytest.mark.proprietary
 class Starshot18(StarMixin, TestCase):
     file_name = "Starshot#18.tiff"
     wobble_center = Point(1516, 1214)
@@ -492,6 +517,7 @@ class Starshot18(StarMixin, TestCase):
     num_rad_lines = 6
 
 
+@pytest.mark.proprietary
 class Starshot19(StarMixin, TestCase):
     file_name = "Starshot#19.tiff"
     wobble_center = Point(1475, 1276)
@@ -499,6 +525,7 @@ class Starshot19(StarMixin, TestCase):
     num_rad_lines = 6
 
 
+@pytest.mark.proprietary
 class Starshot20(StarMixin, TestCase):
     file_name = "Starshot#20.tiff"
     wobble_center = Point(347, 328)
@@ -506,6 +533,7 @@ class Starshot20(StarMixin, TestCase):
     num_rad_lines = 4
 
 
+@pytest.mark.proprietary
 class Starshot21(StarMixin, TestCase):
     file_name = "Starshot#21.tiff"
     wobble_center = Point(354, 294)
@@ -515,6 +543,7 @@ class Starshot21(StarMixin, TestCase):
     passes = False
 
 
+@pytest.mark.proprietary
 class Starshot22(StarMixin, TestCase):
     file_name = "Starshot#22.tiff"
     wobble_center = Point(1305, 1513)
@@ -523,6 +552,7 @@ class Starshot22(StarMixin, TestCase):
     # outside 0.93mm
 
 
+@pytest.mark.proprietary
 class Starshot23(StarMixin, TestCase):
     file_name = "Starshot#23.tiff"
     wobble_center = Point(1297, 1699)
@@ -530,6 +560,7 @@ class Starshot23(StarMixin, TestCase):
     num_rad_lines = 9
 
 
+@pytest.mark.proprietary
 class Starshot24(StarMixin, TestCase):
     file_name = "Starshot#24.tiff"
     wobble_center = Point(1370, 1454)
@@ -537,6 +568,7 @@ class Starshot24(StarMixin, TestCase):
     num_rad_lines = 4
 
 
+@pytest.mark.proprietary
 class Starshot25(StarMixin, TestCase):
     file_name = "Starshot#25.tiff"
     wobble_center = Point(286, 279)
@@ -544,6 +576,7 @@ class Starshot25(StarMixin, TestCase):
     num_rad_lines = 4
 
 
+@pytest.mark.proprietary
 class Starshot26(StarMixin, TestCase):
     file_name = "Starshot#26.tiff"
     wobble_center = Point(1511, 1452)
@@ -552,6 +585,7 @@ class Starshot26(StarMixin, TestCase):
     wobble_tolerance = 0.15
 
 
+@pytest.mark.proprietary
 class Starshot27(StarMixin, TestCase):
     file_name = "Starshot#27.tiff"
     wobble_center = Point(1105, 1306)
@@ -559,6 +593,7 @@ class Starshot27(StarMixin, TestCase):
     num_rad_lines = 6
 
 
+@pytest.mark.proprietary
 class ChicagoSet(StarMixin, TestCase):
     file_name = "Chicago"
     wobble_center = Point(638, 639.3)
@@ -572,6 +607,7 @@ class ChicagoSet(StarMixin, TestCase):
         return get_folder_from_cloud_repo([*cls.dir_path, cls.file_name])
 
 
+@pytest.mark.proprietary
 class MarkerDots(StarMixin, TestCase):
     file_name = "marker_dots.tif"
     wobble_center = Point(566, 559)
@@ -581,6 +617,7 @@ class MarkerDots(StarMixin, TestCase):
     passes = False
 
 
+@pytest.mark.proprietary
 class SyntheticLowValues(StarMixin, TestCase):
     file_name = "synthetic-low-values.zip"
     is_zip = True

--- a/tests_basic/test_vmat.py
+++ b/tests_basic/test_vmat.py
@@ -1,5 +1,6 @@
 import io
 import json
+import pytest
 import tempfile
 from collections.abc import Iterable
 from functools import partial
@@ -129,11 +130,13 @@ class LoadingBase(FromURLTesterMixin, FromDemoImageTesterMixin):
         self.assertEqual(len(my_drgs.segments), 5)
 
 
+@pytest.mark.proprietary
 class TestDRGSLoading(LoadingBase, TestCase):
     url = "drgs.zip"
     klass = DRGS
 
 
+@pytest.mark.proprietary
 class TestDRMLCLoading(LoadingBase, TestCase):
     url = "drmlc.zip"
     klass = DRMLC
@@ -308,6 +311,7 @@ class TestDRMLCDemoRawPixels(TestDRMLCDemo):
     max_r_deviation = 0.56
 
 
+@pytest.mark.proprietary
 class TestDRMLC105(VMATMixin, TestCase):
     """Tests of the result values of MLCS images at 105cm SID."""
 
@@ -326,6 +330,7 @@ class TestDRMLC105(VMATMixin, TestCase):
     passes = False
 
 
+@pytest.mark.proprietary
 class TestDRGS105(VMATMixin, PlotlyTestMixin, TestCase):
     """Tests of the result values of DRMLC images at 105cm SID."""
 
@@ -364,6 +369,7 @@ class TestDRGS105(VMATMixin, PlotlyTestMixin, TestCase):
         self.instance = self.vmat
 
 
+@pytest.mark.proprietary
 class TestDRMLC2(VMATMixin, TestCase):
     """Tests of the result values of MLCS images at 105cm SID."""
 
@@ -379,6 +385,7 @@ class TestDRMLC2(VMATMixin, TestCase):
     passes = False
 
 
+@pytest.mark.proprietary
 class TestDRGS2(VMATMixin, TestCase):
     """Tests of the result values of DRMLC images at 105cm SID."""
 
@@ -393,6 +400,7 @@ class TestDRGS2(VMATMixin, TestCase):
     max_r_deviation = 1.5
 
 
+@pytest.mark.proprietary
 class TestDRMLCWideGaps(VMATMixin, TestCase):
     """Tests of the result values of a perfect DRMLC but with very wide gaps."""
 
@@ -411,6 +419,7 @@ class TestDRMLCWideGaps(VMATMixin, TestCase):
         pass
 
 
+@pytest.mark.proprietary
 class TestDRMLCOverlapGaps(VMATMixin, TestCase):
     """Tests of the result values of a perfect DRMLC but with gaps that are overlapping (e.g. from a poor DLG)."""
 
@@ -429,6 +438,7 @@ class TestDRMLCOverlapGaps(VMATMixin, TestCase):
         pass
 
 
+@pytest.mark.proprietary
 class TestHalcyonDRGS(VMATMixin, TestCase):
     """A Halcyon image is FFF and goes to the edge of the EPID. Causes bad inversion w/o FWXM profile type."""
 
@@ -455,6 +465,7 @@ class TestHalcyonDRGS(VMATMixin, TestCase):
     max_r_deviation = 0.58
 
 
+@pytest.mark.proprietary
 class TestHalcyonDRMLC(VMATMixin, TestCase):
     """A Halcyon image is FFF and goes to the edge of the EPID. Causes bad inversion w/o FWXM profile type."""
 
@@ -480,6 +491,7 @@ class TestHalcyonDRMLC(VMATMixin, TestCase):
     passes = True
 
 
+@pytest.mark.proprietary
 class TestHalcyonDRGS2(VMATMixin, TestCase):
     """A Hal image w/ deep gaps between the ROIs. Causes a shift in the ROIs from RAM-3483"""
 
@@ -496,6 +508,7 @@ class TestHalcyonDRGS2(VMATMixin, TestCase):
     passes = True
 
 
+@pytest.mark.proprietary
 class TestHalcyonDRGS3(VMATMixin, TestCase):
     """A TB image w/ deep gaps between the ROIs. Causes a shift in the ROIs from RAM-3483"""
 

--- a/tests_basic/test_winstonlutz.py
+++ b/tests_basic/test_winstonlutz.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import io
 import math
+import pytest
 import shutil
 import tempfile
 from collections.abc import Sequence
@@ -543,6 +544,7 @@ class TestRotationMatrix(TestCase):
         assert math.isclose(y, 0.707, abs_tol=0.001)
 
 
+@pytest.mark.proprietary
 class TestWLLoading(TestCase, FromDemoImageTesterMixin, FromURLTesterMixin):
     klass = WinstonLutz
     demo_load_method = "from_demo_images"
@@ -831,6 +833,7 @@ class GeneralTests(TestCase):
         self.assertIn("G0B0P0", data_dict["keyed_image_details"].keys())
         self.assertIn("G0B0P0_1", data_dict["keyed_image_details"].keys())
 
+    @pytest.mark.proprietary
     def test_bb_too_far_away_fails(self):
         """BB is >20mm from CAX"""
         file = get_file_from_cloud_test_repo([TEST_DIR, "bb_too_far_away.zip"])
@@ -908,6 +911,7 @@ class TestPlottingSaving(TestCase):
         save_file(self.wl.save_summary)
         save_file(self.wl.save_images)
 
+    @pytest.mark.proprietary
     def test_plot_wo_all_axes(self):
         # test that analyzing images w/o gantry images doesn't fail
         wl_zip = get_file_from_cloud_test_repo([TEST_DIR, "Naming.zip"])
@@ -1384,6 +1388,7 @@ class WLDemo(WinstonLutzMixin, TestCase):
         assert vector_is_close(original_vector, new_vector, delta=0.05)
 
 
+@pytest.mark.proprietary
 class WLPerfect30x8(WinstonLutzMixin, TestCase):
     """30x30mm field, 8mm BB"""
 
@@ -1398,6 +1403,7 @@ class WLPerfect30x8(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector()
 
 
+@pytest.mark.proprietary
 class WLPerfect30x2(WinstonLutzMixin, TestCase):
     """30x30mm field, 2mm BB"""
 
@@ -1413,6 +1419,7 @@ class WLPerfect30x2(WinstonLutzMixin, TestCase):
     bb_size = 2
 
 
+@pytest.mark.proprietary
 class WLPerfect10x4(WinstonLutzMixin, TestCase):
     """10x10mm field, 4mm BB"""
 
@@ -1427,6 +1434,7 @@ class WLPerfect10x4(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector()
 
 
+@pytest.mark.proprietary
 class WLNoisy30x5(WinstonLutzMixin, TestCase):
     """30x30mm field, 5mm BB. S&P noise added"""
 
@@ -1441,6 +1449,7 @@ class WLNoisy30x5(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector()
 
 
+@pytest.mark.proprietary
 class WLLateral3mm(WinstonLutzMixin, TestCase):
     # verified independently
     file_name = "lat3mm.zip"
@@ -1452,6 +1461,7 @@ class WLLateral3mm(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=-3.6, y=0.5, z=0.6)
 
 
+@pytest.mark.proprietary
 class WLReferenceIsLargestRMS(WinstonLutzMixin, TestCase):
     """If the reference image had the largest error, it was not reported"""
 
@@ -1471,6 +1481,7 @@ class WLReferenceIsLargestRMS(WinstonLutzMixin, TestCase):
         )
 
 
+@pytest.mark.proprietary
 class WLLongitudinal3mm(WinstonLutzMixin, TestCase):
     # verified independently
     file_name = "lng3mm.zip"
@@ -1482,6 +1493,7 @@ class WLLongitudinal3mm(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=-0.63, y=3.6, z=0.6)
 
 
+@pytest.mark.proprietary
 class WLVertical3mm(WinstonLutzMixin, TestCase):
     file_name = "vrt3mm.zip"
     num_images = 4
@@ -1493,6 +1505,7 @@ class WLVertical3mm(WinstonLutzMixin, TestCase):
     print_results = True
 
 
+@pytest.mark.proprietary
 class WLDontUseFileNames(WinstonLutzMixin, TestCase):
     file_name = "Naming.zip"
     num_images = 4
@@ -1509,6 +1522,7 @@ class WLDontUseFileNames(WinstonLutzMixin, TestCase):
     }
 
 
+@pytest.mark.proprietary
 class WLUseFileNames(WinstonLutzMixin, PlotlyTestMixin, TestCase):
     file_name = "Naming.zip"
     use_filenames = True
@@ -1532,6 +1546,7 @@ class WLUseFileNames(WinstonLutzMixin, PlotlyTestMixin, TestCase):
         self.instance = self.wl
 
 
+@pytest.mark.proprietary
 class WLBadFilenames(TestCase):
     def test_bad_filenames(self):
         # tests_basic that using filenames with incorrect syntax will fail
@@ -1541,6 +1556,7 @@ class WLBadFilenames(TestCase):
             wl.analyze()
 
 
+@pytest.mark.proprietary
 class KatyiX0(WinstonLutzMixin, PlotlyTestMixin, TestCase):
     # independently verified
     file_name = ["Katy iX", "0.zip"]
@@ -1574,6 +1590,7 @@ class KatyiX0(WinstonLutzMixin, PlotlyTestMixin, TestCase):
         self.instance = self.wl
 
 
+@pytest.mark.proprietary
 class KatyiX1(WinstonLutzMixin, TestCase):
     file_name = ["Katy iX", "1.zip"]
     num_images = 17
@@ -1586,6 +1603,7 @@ class KatyiX1(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=0.3, y=-0.2, z=0.3)
 
 
+@pytest.mark.proprietary
 class KatyiX2(WinstonLutzMixin, TestCase):
     file_name = ["Katy iX", "2.zip"]
     num_images = 17
@@ -1599,6 +1617,7 @@ class KatyiX2(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=0.15, y=-0.15, z=0.1)
 
 
+@pytest.mark.proprietary
 class KatyiX3(WinstonLutzMixin, TestCase):
     file_name = ["Katy iX", "3 (with crosshair).zip"]
     num_images = 17
@@ -1612,6 +1631,7 @@ class KatyiX3(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=-0.1, y=0.2, z=-0.5)
 
 
+@pytest.mark.proprietary
 class KatyTB0(WinstonLutzMixin, TestCase):
     file_name = ["Katy TB", "0.zip"]
     num_images = 17
@@ -1626,6 +1646,7 @@ class KatyTB0(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=-0.4, y=-0.1, z=-0.25)
 
 
+@pytest.mark.proprietary
 class KatyTB1(WinstonLutzMixin, TestCase):
     file_name = ["Katy TB", "1.zip"]
     num_images = 16
@@ -1640,6 +1661,7 @@ class KatyTB1(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=-0.3, y=-0.2)
 
 
+@pytest.mark.proprietary
 class KatyTB2(WinstonLutzMixin, TestCase):
     file_name = ["Katy TB", "2.zip"]
     num_images = 17
@@ -1653,6 +1675,7 @@ class KatyTB2(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=0.0, y=-0.2, z=-0.6)
 
 
+@pytest.mark.proprietary
 class ChicagoTBFinal(WinstonLutzMixin, TestCase):
     # verified independently
     file_name = ["Chicago", "WL-Final_C&G&C_Final.zip"]
@@ -1667,6 +1690,7 @@ class ChicagoTBFinal(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(y=0.1)
 
 
+@pytest.mark.proprietary
 class ChicagoTB52915(WinstonLutzMixin, TestCase):
     file_name = ["Chicago", "WL_05-29-15_Final.zip"]
     num_images = 16
@@ -1679,6 +1703,7 @@ class ChicagoTB52915(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(z=0.2)
 
 
+@pytest.mark.proprietary
 class TrueBeam3120213(WinstonLutzMixin, TestCase):
     file_name = ["TrueBeam 3", "120213.zip"]
     num_images = 26
@@ -1691,6 +1716,7 @@ class TrueBeam3120213(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=-0.1, y=-0.2, z=0.2)
 
 
+@pytest.mark.proprietary
 class SugarLandiX2015(WinstonLutzMixin, TestCase):
     file_name = ["Sugarland iX", "2015", "Lutz2.zip"]
     num_images = 17
@@ -1704,6 +1730,7 @@ class SugarLandiX2015(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=0.6, y=-0.5, z=0.1)
 
 
+@pytest.mark.proprietary
 class BayAreaiX0(WinstonLutzMixin, TestCase):
     # aka the demo images
     file_name = ["Bay Area iX", "0.zip"]
@@ -1718,6 +1745,7 @@ class BayAreaiX0(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=0, y=-0.3, z=-0.2)
 
 
+@pytest.mark.proprietary
 class DAmoursElektaOffset(WinstonLutzMixin, TestCase):
     """An Elekta dataset, with the BB centered."""
 
@@ -1730,6 +1758,7 @@ class DAmoursElektaOffset(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=10.2, y=-9.2, z=-11.1)  # independently verified
 
 
+@pytest.mark.proprietary
 class DAmoursElektaXOffset(WinstonLutzMixin, TestCase):
     """An Elekta dataset, with the BB centered."""
 
@@ -1742,6 +1771,7 @@ class DAmoursElektaXOffset(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=-9.5, y=0.3, z=0.1)  # independently verified
 
 
+@pytest.mark.proprietary
 class DAmoursElektaCentered(WinstonLutzMixin, TestCase):
     """An Elekta dataset, with the BB centered."""
 
@@ -1756,6 +1786,7 @@ class DAmoursElektaCentered(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(y=0.4)
 
 
+@pytest.mark.proprietary
 class DeBr6XElekta(WinstonLutzMixin, TestCase):
     """An Elekta dataset, with the BB centered."""
 
@@ -1770,6 +1801,7 @@ class DeBr6XElekta(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=0.4, y=-0.2)
 
 
+@pytest.mark.proprietary
 class LargeFieldCouchPresent(WinstonLutzMixin, TestCase):
     """A very large field where the couch is present"""
 
@@ -1784,6 +1816,7 @@ class LargeFieldCouchPresent(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=0.5, y=-0.7, z=0.8)
 
 
+@pytest.mark.proprietary
 class LowDensityBB(WinstonLutzMixin, TestCase):
     """An air-like BB where the signal increases vs attenuates. Requires passing the right parameter"""
 
@@ -1799,6 +1832,7 @@ class LowDensityBB(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=0, y=0, z=0)
 
 
+@pytest.mark.proprietary
 class kVImages(WinstonLutzMixin, TestCase):
     """kV image-based WL set. Have to set the parameters correctly"""
 
@@ -1817,6 +1851,7 @@ class kVImages(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=-0.24, y=0, z=0)
 
 
+@pytest.mark.proprietary
 class TIFFImages(WinstonLutzMixin, TestCase):
     """Tiff image set. Hell hath frozen over"""
 
@@ -1840,6 +1875,7 @@ class TIFFImages(WinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=0.74, y=0.16, z=-0.14)
 
 
+@pytest.mark.proprietary
 class VarianBBkV(WinstonLutzMixin, TestCase):
     """kV image-based WL set using the super tiny Varian BB. Have to set the parameters correctly"""
 
@@ -1915,6 +1951,7 @@ class GeneratedWLCBCT:
         )
 
 
+@pytest.mark.proprietary
 class CBCTWinstonLutzMixin(WinstonLutzMixin):
     low_density_bb = True
     open_field = True
@@ -1961,6 +1998,7 @@ class CBCTWinstonLutzMixin(WinstonLutzMixin):
             print(cls.wl.bb_shift_vector)
 
 
+@pytest.mark.proprietary
 class TestFrenchCBCT(CBCTWinstonLutzMixin, TestCase):
     file_name = ["cbct_wl_real.zip"]
     cax2bb_max_distance = 0.23
@@ -1970,6 +2008,7 @@ class TestFrenchCBCT(CBCTWinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=0.2, y=0, z=-0.2)
 
 
+@pytest.mark.proprietary
 class TestPerfectCBCT(GeneratedWLCBCT, CBCTWinstonLutzMixin, TestCase):
     bb_offset = {"left": 0, "up": 0, "in": 0}
     cax2bb_max_distance = 0
@@ -1978,6 +2017,7 @@ class TestPerfectCBCT(GeneratedWLCBCT, CBCTWinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=0, y=0, z=0)
 
 
+@pytest.mark.proprietary
 class TestOffsetLeftCBCT(GeneratedWLCBCT, CBCTWinstonLutzMixin, TestCase):
     bb_offset = {"left": 5, "up": 0, "in": 0}
     cax2bb_max_distance = 5
@@ -1986,6 +2026,7 @@ class TestOffsetLeftCBCT(GeneratedWLCBCT, CBCTWinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=-5, y=0, z=0)
 
 
+@pytest.mark.proprietary
 class TestOffsetDownCBCT(GeneratedWLCBCT, CBCTWinstonLutzMixin, TestCase):
     bb_offset = {"left": 0, "up": -5, "in": 0}
     cax2bb_max_distance = 5
@@ -1994,6 +2035,7 @@ class TestOffsetDownCBCT(GeneratedWLCBCT, CBCTWinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=0, y=0, z=5)
 
 
+@pytest.mark.proprietary
 class TestOffsetInCBCT(GeneratedWLCBCT, CBCTWinstonLutzMixin, TestCase):
     bb_offset = {"left": 0, "up": 0, "in": 5}
     cax2bb_max_distance = 5
@@ -2002,6 +2044,7 @@ class TestOffsetInCBCT(GeneratedWLCBCT, CBCTWinstonLutzMixin, TestCase):
     bb_shift_vector = Vector(x=0, y=-5, z=0)
 
 
+@pytest.mark.proprietary
 class TestIndividualInverts(WinstonLutzMixin, TestCase):
     # see RAM-3252; still need to crop
     # but now the images are inverted after cropping

--- a/tests_basic/test_winstonlutz_mtmf.py
+++ b/tests_basic/test_winstonlutz_mtmf.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 import shutil
 import tempfile
 from collections.abc import Sequence
@@ -200,6 +201,7 @@ class WinstonLutzMultiTargetMultFieldMixin(CloudFileMixin):
         )
 
 
+@pytest.mark.proprietary
 class SNCMultiMet(WinstonLutzMultiTargetMultFieldMixin, TestCase):
     dir_path = ["Winston-Lutz", "multi_target_multi_field"]
     file_name = "SNC_MM_KB.zip"
@@ -268,6 +270,8 @@ class SyntheticMultiMetMixin(WinstonLutzMultiTargetMultFieldMixin):
         return len(self.images_axes)
 
 
+
+@pytest.mark.proprietary
 class SyntheticPerfect1BB(SyntheticMultiMetMixin, TestCase):
     arrangement = (
         BBConfig(
@@ -288,6 +292,8 @@ class SyntheticPerfect1BB(SyntheticMultiMetMixin, TestCase):
     mean_2d_distance = 0
 
 
+
+@pytest.mark.proprietary
 class Synthetic1BBOffsetIn(SyntheticMultiMetMixin, PlotlyTestMixin, TestCase):
     arrangement = (
         BBConfig(
@@ -320,6 +326,8 @@ class Synthetic1BBOffsetIn(SyntheticMultiMetMixin, PlotlyTestMixin, TestCase):
         self.instance = self.wl
 
 
+
+@pytest.mark.proprietary
 class Synthetic1BBOffsetLeft(SyntheticMultiMetMixin, TestCase):
     arrangement = (
         BBConfig(
@@ -341,6 +349,8 @@ class Synthetic1BBOffsetLeft(SyntheticMultiMetMixin, TestCase):
     bb_shift_vector = Vector(1, 0, 0)
 
 
+
+@pytest.mark.proprietary
 class Synthetic1BBOffsetUp(SyntheticMultiMetMixin, TestCase):
     arrangement = (
         BBConfig(
@@ -362,6 +372,8 @@ class Synthetic1BBOffsetUp(SyntheticMultiMetMixin, TestCase):
     bb_shift_vector = Vector(0, 0, -1)
 
 
+
+@pytest.mark.proprietary
 class Synthetic3BBPerfect(SyntheticMultiMetMixin, TestCase):
     arrangement = (
         BBConfig(
@@ -398,6 +410,8 @@ class Synthetic3BBPerfect(SyntheticMultiMetMixin, TestCase):
     mean_2d_distance = 0
 
 
+
+@pytest.mark.proprietary
 class Synthetic2BBYaw(SyntheticMultiMetMixin, TestCase):
     arrangement = (
         BBConfig(
@@ -436,6 +450,8 @@ class Synthetic2BBYaw(SyntheticMultiMetMixin, TestCase):
     bb_max_2d_yaw = 91.8  # not realistic due to choice of BB placement symmetry (roll is 180 degrees in one case), but it's the max; note the 91.8-90=1.8
 
 
+
+@pytest.mark.proprietary
 class Synthetic2BBRoll(SyntheticMultiMetMixin, TestCase):
     arrangement = (
         BBConfig(

--- a/uv.lock
+++ b/uv.lock
@@ -1326,7 +1326,7 @@ wheels = [
 
 [[package]]
 name = "pylinac"
-version = "3.29.0"
+version = "3.31.0"
 source = { editable = "." }
 dependencies = [
     { name = "argue" },
@@ -1379,12 +1379,12 @@ requires-dist = [
     { name = "eval-type-backport", marker = "python_full_version < '3.10'" },
     { name = "furo", marker = "extra == 'docs'", specifier = ">=2024.8.6" },
     { name = "matplotlib", specifier = ">=3.0" },
-    { name = "numpy", specifier = ">=1.20,<2" },
+    { name = "numpy", specifier = "<2,>=1.20" },
     { name = "pillow", specifier = ">=4.0" },
     { name = "plotly", specifier = ">=5.0" },
     { name = "py-linq", specifier = "~=1.4.0" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "pydicom", specifier = ">=2.0,<3" },
+    { name = "pydicom", specifier = "<3,>=2.0" },
     { name = "quaac" },
     { name = "reportlab", specifier = ">=3.3" },
     { name = "scikit-image", specifier = ">=0.18" },


### PR DESCRIPTION
This PR aims to resolve #543 by adding markers to any test that requires non-public data.

1. A new pytest marker "proprietary" was added and applied to relevant tests. If all tests in a `TestCase` class would be marked, the class itself was marked instead. If all tests in a module would be marked, the module as a whole was marked with `pytestmark = pytest.mark.proprietary` instead.
1. Proprietary test files that were loaded on module import were either moved to class methods or pytest fixtures.
1. CI/CD piplines were marked with the `-m 'proprietary or not proprietary` option.