### PR TITLE
Fix incorrect DICOM stack ordering when check UID is used issue #551

### DIFF
--- a/pylinac/core/image.py
+++ b/pylinac/core/image.py
@@ -1737,12 +1737,9 @@ class LazyDicomImageStack:
         # error checking
         if check_uid:
             most_common_uid = self._get_common_uid_imgs(metadatas, min_number)
+            paths = [p for p, m in zip(paths, metadatas)
+                     if m.SeriesInstanceUID == most_common_uid]
             metadatas = [m for m in metadatas if m.SeriesInstanceUID == most_common_uid]
-            paths = [
-                p
-                for p, m in zip(paths, metadatas)
-                if m.SeriesInstanceUID == most_common_uid
-            ]
         # sort according to physical order
         order = np.argsort([m.ImagePositionPatient[-1] for m in metadatas])
         self.metadatas = [metadatas[i] for i in order]
@@ -1868,12 +1865,9 @@ class LazyZipDicomImageStack(LazyDicomImageStack):
         # error checking
         if check_uid:
             most_common_uid = self._get_common_uid_imgs(metadatas, min_number)
+            paths = [p for p, m in zip(paths, metadatas)
+                     if m.SeriesInstanceUID == most_common_uid]
             metadatas = [m for m in metadatas if m.SeriesInstanceUID == most_common_uid]
-            paths = [
-                p
-                for p, m in zip(paths, metadatas)
-                if m.SeriesInstanceUID == most_common_uid
-            ]
         # sort according to physical order
         order = np.argsort([m.ImagePositionPatient[-1] for m in metadatas])
         self.metadatas = [metadatas[i] for i in order]

--- a/tests_basic/core/test_image.py
+++ b/tests_basic/core/test_image.py
@@ -811,6 +811,7 @@ class TestDicomStack(TestCase):
     def test_lazy_with_multiple_uids_updates_paths(self):
         # issue 494
         # join two stacks into a temporary dir
+        # TODO test stack order issue #551
         stack1 = get_file_from_cloud_test_repo(["CBCT", "CatPhan_504", "CBCT_5.zip"])
         stack2 = get_file_from_cloud_test_repo(["CBCT", "CatPhan_504", "CBCT_3.zip"])
         new_dir = tempfile.mkdtemp()


### PR DESCRIPTION
Changed `LazyDicomImageStack` and `LazyZipDicomImageStack` as described in #551. Put placeholder TODO in test_image.py::test_lazy_with_multiple_uids_updates_paths to check this when tests are sorted.