### PR TITLE
Improves XIM reading in pure python

### DIFF
--- a/pylinac/core/image.py
+++ b/pylinac/core/image.py
@@ -1119,11 +1119,9 @@ class XIM(BaseImage):
             This is ripe for optimization, but brevity and clarity won out. Options include bit-shifting (fastest)
             and numpy.packbits/unpackbits.
         """
-
-        unpacked = np.unpackbits(lookup_table_bytes, bitorder="little")
-        reshaped = unpacked.reshape((-1, 2))
-        packed = np.packbits(reshaped, axis=-1, bitorder="little")[:, 0]
-        return packed
+        bit_shift = np.array([0, 2, 4, 6])
+        lookup_table = (lookup_table_bytes[:, np.newaxis] >> bit_shift[np.newaxis, :]) & 0b00000011
+        return lookup_table.flatten()
 
     def _parse_compressed_bytes(
         self, xim: BinaryIO, lookup_table: np.ndarray


### PR DESCRIPTION
@jrkerns 
Improve https://github.com/jrkerns/pylinac/issues/546 part 2 with no help from crustaceans. And incidentally with exactly 0 net line changes!

This PR improves the XIM parsing speed to ~30ms over 3 commits. Each commit should work independently of the others, so you can test each one to see how much of a speed increase each one has.

The biggest speed gain was from using numpy sliding windows, which reinterprets the decompression algorithm to be more friendly to array operations, meaning the python loop is just over the rows of the image, rather than each element. Additionally, I removed the conversions to floats, using numpy functions to use overflowing arithmetic instead. This is similar to how I wrote the rust package. 

Some notes: I had to change the dtypes of the arrays from uints to signed ints. I am unsure what the reason was, but the overflow arithmetic didn't seem to work correctly when using unsigned ints. This does technically change the API, and I'm also not sure whether this is correct for the format.

On my computer, the speed started at 1.09s, and the times for each of the commits in order are as follows
914ms (packbits)
103 ms (sliding windows over the image height)
30.4 ms (improved splitting of the array based on byte lengths)

(The rust implementation is ~10ms for reference)


I have no idea why I was so determined to improve this but hopefully it's helpful! 
