### PR TITLE
Instantiating Pylinac classes from Pydicom datasets issue #550

### DIFF
--- a/pylinac/core/image.py
+++ b/pylinac/core/image.py
@@ -1337,18 +1337,12 @@ class DicomImage(BaseImage):
         self.metadata = retrieve_dicom_file(path)
         self._original_dtype = self.metadata.pixel_array.dtype
         self._raw_pixels = raw_pixels
-        # read a second time to get pixel data
-        try:
-            path.seek(0)
-        except AttributeError:
-            pass
-        ds = retrieve_dicom_file(path)
         if dtype is not None:
-            self.array = ds.pixel_array.astype(dtype)
+            self.array = self.metadata.pixel_array.astype(dtype)
         else:
-            self.array = ds.pixel_array.copy()
+            self.array = self.metadata.pixel_array.copy()
         # convert values to HU or CU
-        self.array = _rescale_dicom_values(self.array, ds, raw_pixels=raw_pixels)
+        self.array = _rescale_dicom_values(self.array, self.metadata, raw_pixels=raw_pixels)
 
     @classmethod
     def from_dataset(cls, dataset: Dataset):

--- a/pylinac/core/image.py
+++ b/pylinac/core/image.py
@@ -1745,9 +1745,13 @@ class LazyDicomImageStack:
                      if m.SeriesInstanceUID == most_common_uid]
             metadatas = [m for m in metadatas if m.SeriesInstanceUID == most_common_uid]
         # sort according to physical order
-        order = np.argsort([m.ImagePositionPatient[-1] for m in metadatas])
-        self.metadatas = [metadatas[i] for i in order]
-        self._image_path_keys = [paths[i] for i in order]
+        if hasattr(metadatas[0], "ImagePositionPatient"):        # ACC some image series like w-l does not have ImagePositionPatient
+            order = np.argsort([m.ImagePositionPatient[-1] for m in metadatas])
+            self.metadatas = [metadatas[i] for i in order]
+            self._image_path_keys = [paths[i] for i in order]
+        else:
+            self.metadatas = metadatas
+            self._image_path_keys = paths
 
     @classmethod
     def from_zip(cls, zip_path: str | Path, dtype: np.dtype | None = None, **kwargs):

--- a/pylinac/core/image.py
+++ b/pylinac/core/image.py
@@ -1736,12 +1736,9 @@ class LazyDicomImageStack:
         # error checking
         if check_uid:
             most_common_uid = self._get_common_uid_imgs(metadatas, min_number)
+            paths = [p for p, m in zip(paths, metadatas)
+                     if m.SeriesInstanceUID == most_common_uid]
             metadatas = [m for m in metadatas if m.SeriesInstanceUID == most_common_uid]
-            paths = [
-                p
-                for p, m in zip(paths, metadatas)
-                if m.SeriesInstanceUID == most_common_uid
-            ]
         # sort according to physical order
         order = np.argsort([m.ImagePositionPatient[-1] for m in metadatas])
         self.metadatas = [metadatas[i] for i in order]
@@ -1867,12 +1864,9 @@ class LazyZipDicomImageStack(LazyDicomImageStack):
         # error checking
         if check_uid:
             most_common_uid = self._get_common_uid_imgs(metadatas, min_number)
+            paths = [p for p, m in zip(paths, metadatas)
+                     if m.SeriesInstanceUID == most_common_uid]
             metadatas = [m for m in metadatas if m.SeriesInstanceUID == most_common_uid]
-            paths = [
-                p
-                for p, m in zip(paths, metadatas)
-                if m.SeriesInstanceUID == most_common_uid
-            ]
         # sort according to physical order
         order = np.argsort([m.ImagePositionPatient[-1] for m in metadatas])
         self.metadatas = [metadatas[i] for i in order]

--- a/pylinac/core/image.py
+++ b/pylinac/core/image.py
@@ -154,7 +154,7 @@ def retrieve_image_files(path: str) -> list[str]:
     return retrieve_filenames(directory=path, func=is_image)
 
 
-def load(path: str | Path | ImageLike | np.ndarray | BinaryIO, **kwargs) -> ImageLike:
+def load(path: str | Path | ImageLike | np.ndarray | BinaryIO | Dataset, **kwargs) -> ImageLike:
     r"""Load a DICOM image, JPG/TIF/BMP image, or numpy 2D array.
 
     Parameters
@@ -189,7 +189,7 @@ def load(path: str | Path | ImageLike | np.ndarray | BinaryIO, **kwargs) -> Imag
 
     if _is_array(path):
         return ArrayImage(path, **kwargs)
-    elif _is_dicom(path):
+    elif _is_dicom(path) or _is_dataset(path):
         return DicomImage(path, **kwargs)
     elif _is_image_file(path):
         return FileImage(path, **kwargs)
@@ -379,6 +379,11 @@ def _is_xim(path: str | Path) -> bool:
 def _is_array(obj: Any) -> bool:
     """Whether the object is a numpy array."""
     return isinstance(obj, np.ndarray)
+
+
+def _is_dataset(obj: Any) -> bool:
+    """Whether the object is a pydicom dataset"""
+    return isinstance(obj, Dataset)
 
 
 class BaseImage:

--- a/pylinac/core/image.py
+++ b/pylinac/core/image.py
@@ -66,6 +66,7 @@ IMAGE = "Image"
 
 FILE_TYPE = "file"
 STREAM_TYPE = "stream"
+DATASET_TYPE = "dataset"
 
 XIM_PROP_INT = 0
 XIM_PROP_DOUBLE = 1
@@ -398,7 +399,7 @@ class BaseImage:
     source: FILE_TYPE | STREAM_TYPE
 
     def __init__(
-        self, path: str | Path | BytesIO | ImageLike | np.ndarray | BufferedReader
+        self, path: str | Path | BytesIO | ImageLike | np.ndarray | BufferedReader | Dataset
     ):
         """
         Parameters
@@ -417,6 +418,9 @@ class BaseImage:
             self.path = path
             self.base_path = osp.basename(path)
             self.source = FILE_TYPE
+        elif isinstance(path, Dataset):
+            self.source = DATASET_TYPE
+            self.path = ""
         else:
             self.source = STREAM_TYPE
             path.seek(0)

--- a/pylinac/ct.py
+++ b/pylinac/ct.py
@@ -38,6 +38,7 @@ from pydantic import BaseModel, Field
 from scipy import ndimage
 from skimage import draw, filters, measure, segmentation
 from skimage.measure._regionprops import RegionProperties
+from pydicom import Dataset
 
 from .core import image, pdf
 from .core.contrast import Contrast
@@ -1862,6 +1863,11 @@ class CatPhanBase(ResultsDataMixin[CatphanResult], QuaacMixin):
             memory_efficient_mode=memory_efficient_mode,
             is_zip=True,
         )
+
+    @classmethod
+    def from_dataset(cls, ds_list: list[Dataset]):
+        dis = DicomImageStack(ds_list)
+        return cls(dis)
 
     def plotly_analyzed_images(
         self,

--- a/pylinac/ct.py
+++ b/pylinac/ct.py
@@ -1766,7 +1766,7 @@ class CatPhanBase(ResultsDataMixin[CatphanResult], QuaacMixin):
 
     def __init__(
         self,
-        folderpath: str | Sequence[str] | Path | Sequence[Path] | Sequence[BytesIO],
+        folderpath: str | Sequence[str] | Path | Sequence[Path] | Sequence[BytesIO] | DicomImageStack,
         check_uid: bool = True,
         memory_efficient_mode: bool = False,
         is_zip: bool = False,
@@ -1805,6 +1805,8 @@ class CatPhanBase(ResultsDataMixin[CatphanResult], QuaacMixin):
             self.dicom_stack = stack.from_zip(
                 folderpath, check_uid=check_uid, min_number=self.min_num_images
             )
+        elif isinstance(folderpath, DicomImageStack):
+            self.dicom_stack = folderpath
         else:
             self.dicom_stack = stack(
                 folderpath, check_uid=check_uid, min_number=self.min_num_images

--- a/tests_basic/core/test_image.py
+++ b/tests_basic/core/test_image.py
@@ -811,6 +811,7 @@ class TestDicomStack(TestCase):
     def test_lazy_with_multiple_uids_updates_paths(self):
         # issue 494
         # join two stacks into a temporary dir
+        # TODO test stack order issue #551
         stack1 = get_file_from_cloud_test_repo(["CBCT", "CatPhan_504", "CBCT_5.zip"])
         stack2 = get_file_from_cloud_test_repo(["CBCT", "CatPhan_504", "CBCT_3.zip"])
         new_dir = tempfile.mkdtemp()

--- a/uv.lock
+++ b/uv.lock
@@ -190,7 +190,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -1326,7 +1326,7 @@ wheels = [
 
 [[package]]
 name = "pylinac"
-version = "3.29.0"
+version = "3.31.0"
 source = { editable = "." }
 dependencies = [
     { name = "argue" },
@@ -1941,7 +1941,7 @@ name = "tqdm"
 version = "4.66.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/83/6ba9844a41128c62e810fddddd72473201f3eacde02046066142a2d96cc5/tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad", size = 169504 }
 wheels = [


### PR DESCRIPTION
As proof of concept I have this working. You can do:
```
from pydicom import dcmread
from pylinac.core.image import DicomImageStack, DicomImage, load
from pylinac import CatPhan604
import matplotlib
matplotlib.use('TkAgg')
from pathlib import Path
import os.path as osp

test_dir = r'/home/.../TestFiles/CatPhan604/'
ds_list =[dcmread(path) for path in Path(test_dir).iterdir()]
dis = DicomImageStack(ds_list, min_number=3)
ct = CatPhan604(dis)
ct.analyze()
ct.publish_pdf(osp.join(test_dir,'result.pdf'))
```
or
```
test_dir = r'/home/.../TestFiles/CatPhan604/'
ds_list =[dcmread(path) for path in Path(test_dir).iterdir()]
ct = CatPhan604.from_dataset(ds_list)
ct.analyze()
ct.publish_pdf(osp.join(test_dir,'result.pdf'))
```
There is still a lot of work to be done, but at this stage I need to know that I haven't broken something upstream. The tests, such as I've been able to run, are passing, but I can only 42 of the 702 tests are running. @jrkerns, again, when you have a gap please run the test suite on this PR. I've also incorporated the commits from PR 547 and 553 in this PR.

Regards
Alan