### PR TITLE
Use vectorized_filter for gamma_2d

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylinac"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 description = "A toolkit for performing TG-142 QA-related tasks on a linear accelerator"
 authors = [
     {name = "James Kerns", email = "jkerns100@gmail.com"}
@@ -31,7 +31,7 @@ dependencies = [
     "scikit-image>=0.18; python_version<'3.13'",
     "scikit-image>=0.25; python_version>='3.13'",
     "numpy>=1.22",
-    "scipy>=1.11.0",
+    "scipy>=1.16.0",
     "tqdm>=3.8",
     "Pillow>=4.0",
     "argue~=0.3.1",


### PR DESCRIPTION
Partially addresses https://github.com/jrkerns/pylinac/issues/562

This uses the prerelease of scipy 1.16 to try out vectorized_filter for `gamma_2d`. 
The improvement in speed for a 400x400 image is from ~7 seconds to 0.008 seconds(so ~1000x improvement). I think some of the improvement could come if we just used `generic_filter`, so I can switch to using that if that works better, but the difference won't be nearly as drastic(though I expect it'll still be pretty drastic).

One problem is needing to bump the required python version to 3.11 from 3.9. I'll leave this in draft mode until scipy 1.16 is released, which should be mid-june per https://discuss.scientific-python.org/t/proposed-release-schedule-for-scipy-1-16-0/1883

