### PR TITLE
Moves optional dependencies to dependency groups

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ build:
       python: "3.11"
    jobs:
       post_install:
-         - pip install .[docs]
+         - pip install --group docs .

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -21,7 +21,7 @@ definitions:
           - apt-get update
           - apt-get -y install git
           - uv venv
-          - uv pip install .[developer]
+          - uv pip install . --group dev
           - uv pip freeze
           - uv tool run pre-commit run --all-files
         caches:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "plotly>=5.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 docs = [
     "sphinx-autobuild>=2021.3.14",
     "sphinx-copybutton>=0.5.2",
@@ -55,7 +55,8 @@ docs = [
     "furo>=2024.8.6",
     "autodoc-pydantic>=2.1.0",
 ]
-developer = [
+
+dev = [
     "google-cloud-storage>=2.18.2",
     "nox>=2024.4.15",
     "parameterized>=0.9.0",


### PR DESCRIPTION
A quick explanation of dependency groups is [here](https://docs.astral.sh/uv/concepts/projects/dependencies/#development-dependencies), but essentially, they are meant for dependencies used during development/CI, whereas optional dependencies are meant for the library consumer. Additionally, they are a python standard, rather than uv specific, so other tools should support them.

