### PR TITLE
Remove rotation shifts in Multi-target Winston-Lutz when <3 BBs

### DIFF
--- a/pylinac/winston_lutz.py
+++ b/pylinac/winston_lutz.py
@@ -3628,7 +3628,7 @@ def align_points(
     ideal_centroid = np.mean(ideal_array, axis=0)
 
     # Rotational components are under-determined for <3 points; fall back to translation only.
-    if measured_array.shape[0] < 3:
+    if len(measured_points) < 3:
         translation = ideal_centroid - measured_centroid
         return Vector(*translation), 0.0, 0.0, 0.0
     


### PR DESCRIPTION
When running MT Winston-Lutz using a custom phantom with two BBs, it doesn't make sense to calculate a pitch, roll, and yaw for bb_shift_instructions since the two BB phantom is under-constrained. It should instead default to a 3DOF translation and set pitch, roll, and yaw to 0.0.

<img width="787" height="29" alt="image" src="https://github.com/user-attachments/assets/7ad5457a-b717-45a4-91c5-91f50133b3a2" />

Otherwise it reports non-sensical rotations in bb_shift_instructions when allowed to perform the SVD calculation to solve the euler angles.

<img width="817" height="24" alt="image" src="https://github.com/user-attachments/assets/2b2c164c-2529-4ed3-b441-fe40587f8f15" />
