### PR TITLE
Phantom roll override

### DIFF
--- a/pylinac/ct.py
+++ b/pylinac/ct.py
@@ -2351,14 +2351,21 @@ class CatPhanBase(ResultsDataMixin[CatphanResult], QuaacMixin):
             mtfs[mtf] = mtfval
         print(f"MTFs: {mtfs}")
 
-    def localize(self, origin_slice: int | None) -> None:
+    def localize(
+        self,
+        origin_slice: int | None,
+        phantom_roll: float | None = None,
+    ) -> None:
         """Find the slice number of the catphan's HU linearity module and roll angle"""
         self._phantom_center_func = self.find_phantom_axis()
         if origin_slice is not None:
             self.origin_slice = origin_slice
         else:
             self.origin_slice = self.find_origin_slice()
-        self.catphan_roll = self.find_phantom_roll() + self.angle_adjustment
+        if phantom_roll is not None:
+            self.catphan_roll = phantom_roll
+        else:
+            self.catphan_roll = self.find_phantom_roll() + self.angle_adjustment
         if origin_slice is None:
             self.origin_slice = self.refine_origin_slice(
                 initial_slice_num=self.origin_slice
@@ -2725,6 +2732,7 @@ class CatPhanBase(ResultsDataMixin[CatphanResult], QuaacMixin):
         roi_size_factor: float = 1,
         scaling_factor: float = 1,
         origin_slice: int | None = None,
+        phantom_roll: float | None = None,
         roll_slice_offset: float = 0,
     ):
         """Single-method full analysis of CBCT DICOM files.
@@ -2790,6 +2798,9 @@ class CatPhanBase(ResultsDataMixin[CatphanResult], QuaacMixin):
         origin_slice : int, None
             The slice number of the HU linearity module. If None, the slice will be determined automatically. This is
             a fallback method if the automatic localization algorithm fails.
+        phantom_roll : float, None
+            The phantom roll in degrees. If None, the roll will be determined automatically. This is
+            a fallback method if the automatic roll detection algorithm fails.
         roll_slice_offset : float
             The offset in mm from ``origin_slice`` used to select the slice for phantom
             roll detection. The phantom roll is determined based on the two
@@ -2803,7 +2814,7 @@ class CatPhanBase(ResultsDataMixin[CatphanResult], QuaacMixin):
         self.roi_size_factor = roi_size_factor
         self.scaling_factor = scaling_factor
         self.roll_slice_offset = roll_slice_offset
-        self.localize(origin_slice)
+        self.localize(origin_slice=origin_slice, phantom_roll=phantom_roll)
         ctp404, offset = self._get_module(CTP404CP504, raise_empty=True)
         self.ctp404 = ctp404(
             self,

--- a/tests_basic/test_cbct.py
+++ b/tests_basic/test_cbct.py
@@ -240,6 +240,17 @@ class TestGeneral(TestCase):
         ct.analyze(origin_slice=46)  # automatic slice is 45
         self.assertEqual(ct.origin_slice, 46)
 
+    def test_passing_phantom_roll_works(self):
+        ct = CatPhan504.from_demo_images()
+        ct.analyze(phantom_roll=3.5)
+        self.assertEqual(ct.catphan_roll, 3.5)
+
+    def test_passing_phantom_roll_skips_auto_detection(self):
+        ct = CatPhan504.from_demo_images()
+        ct.find_phantom_roll = lambda: self.fail("phantom roll auto-detection ran")
+        ct.analyze(phantom_roll=-2.25)
+        self.assertEqual(ct.catphan_roll, -2.25)
+
 
 class Test503Quaac(QuaacTestBase, TestCase):
     def quaac_instance(self):


### PR DESCRIPTION
For Catphan acquisitons with poor image quality, `find_phantom_roll()` can fail to identify the air bubbles. There is already a solution for when the algorithm fails to find the `origin_slice` - it can be overridden.

This PR replicates this solution for `phantom_roll`.

This has been tested and runs successfully on CatPhan CBCT acquisitions that both did and did correctly identify the phantom roll.