### PR TITLE
tests: make cloud-backed test data auth-aware and standardize with requires_cloud_data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,6 @@ $RECYCLE.BIN/
 *.lnk
 
 tests_basic/test_files
+
+# Google Cloud Platform credentials file
+GCP_creds.json

--- a/tests_basic/contrib/test_orthogonality.py
+++ b/tests_basic/contrib/test_orthogonality.py
@@ -2,13 +2,14 @@ from pathlib import Path
 from unittest import TestCase
 
 from pylinac.contrib.orthogonality import JawOrthogonality
-from tests_basic.utils import get_folder_from_cloud_repo
+from tests_basic.utils import requires_cloud_data
 
 
 class TestOrthogonality(TestCase):
     @classmethod
-    def setUpClass(cls) -> None:
-        cls.dir = Path(get_folder_from_cloud_repo(["planar_imaging", "Orthogonality"]))
+    @requires_cloud_data(folders={"cloud_dir": ["planar_imaging", "Orthogonality"]})
+    def setUpClass(cls, cloud_dir: str) -> None:
+        cls.dir = Path(cloud_dir)
 
     def test_analyze(self):
         for file in self.dir.iterdir():

--- a/tests_basic/contrib/test_quasar.py
+++ b/tests_basic/contrib/test_quasar.py
@@ -2,13 +2,14 @@ from pathlib import Path
 from unittest import TestCase
 
 from pylinac.contrib.quasar import QuasarLightRadScaling
-from tests_basic.utils import get_folder_from_cloud_repo
+from tests_basic.utils import requires_cloud_data
 
 
 class TestQuasar(TestCase):
     @classmethod
-    def setUpClass(cls) -> None:
-        cls.dir = Path(get_folder_from_cloud_repo(["planar_imaging", "Quasar"]))
+    @requires_cloud_data(folders={"cloud_dir": ["planar_imaging", "Quasar"]})
+    def setUpClass(cls, cloud_dir: str) -> None:
+        cls.dir = Path(cloud_dir)
 
     def test_analyze(self):
         for file in self.dir.iterdir():

--- a/tests_basic/core/test_image.py
+++ b/tests_basic/core/test_image.py
@@ -1,4 +1,5 @@
 import copy
+import functools
 import io
 import json
 import math
@@ -8,6 +9,7 @@ import tempfile
 import unittest
 import zipfile
 from builtins import ValueError
+from functools import lru_cache
 from pathlib import Path
 from unittest import TestCase
 
@@ -47,16 +49,106 @@ from tests_basic.utils import (
     save_file,
 )
 
-bad_tif_path = get_file_from_cloud_test_repo(["Winston-Lutz", "AQA_A_03082023.tif"])
-tif_path = get_file_from_cloud_test_repo(["Starshot", "Starshot-1.tif"])
-png_path = get_file_from_cloud_test_repo(["Starshot", "Starshot-1.png"])
-dcm_path = get_file_from_cloud_test_repo(["VMAT", "DRGSdmlc-105-example.dcm"])
-as500_path = get_file_from_cloud_test_repo(["picket_fence", "AS500#5.dcm"])
-xim_path = get_file_from_cloud_test_repo(["ximdcmtest.xim"])
-xim_dcm_path = get_file_from_cloud_test_repo(["ximdcmtest.dcm"])
+bad_tif_path = ""
+tif_path = ""
+png_path = ""
+dcm_path = ""
+as500_path = ""
+xim_path = ""
+xim_dcm_path = ""
 dcm_url = "https://storage.googleapis.com/pylinac_demo_files/EPID-PF-LR.dcm"
 
 
+@lru_cache(maxsize=1)
+def _resolve_core_image_cloud_paths() -> dict[str, str]:
+    return {
+        "bad_tif_path": get_file_from_cloud_test_repo(
+            ["Winston-Lutz", "AQA_A_03082023.tif"]
+        ),
+        "tif_path": get_file_from_cloud_test_repo(["Starshot", "Starshot-1.tif"]),
+        "png_path": get_file_from_cloud_test_repo(["Starshot", "Starshot-1.png"]),
+        "dcm_path": get_file_from_cloud_test_repo(["VMAT", "DRGSdmlc-105-example.dcm"]),
+        "as500_path": get_file_from_cloud_test_repo(["picket_fence", "AS500#5.dcm"]),
+        "xim_path": get_file_from_cloud_test_repo(["ximdcmtest.xim"]),
+        "xim_dcm_path": get_file_from_cloud_test_repo(["ximdcmtest.dcm"]),
+    }
+
+
+def _ensure_core_image_cloud_paths() -> None:
+    global \
+        as500_path, \
+        bad_tif_path, \
+        dcm_path, \
+        png_path, \
+        tif_path, \
+        xim_dcm_path, \
+        xim_path
+    paths = _resolve_core_image_cloud_paths()
+    bad_tif_path = paths["bad_tif_path"]
+    tif_path = paths["tif_path"]
+    png_path = paths["png_path"]
+    dcm_path = paths["dcm_path"]
+    as500_path = paths["as500_path"]
+    xim_path = paths["xim_path"]
+    xim_dcm_path = paths["xim_dcm_path"]
+
+
+def _decorate_core_cloud_test_class(cls: type[TestCase]) -> type[TestCase]:
+    original_set_up_class = getattr(cls, "setUpClass", None)
+
+    @classmethod
+    def set_up_class(inner_cls):
+        _ensure_core_image_cloud_paths()
+        if original_set_up_class is not None:
+            original_set_up_class()
+
+    cls.setUpClass = set_up_class
+    return cls
+
+
+def requires_core_image_cloud_data(*args, **kwargs):
+    """Decorator for class-level shared cloud paths or test-level specific files.
+
+    Class usage
+    -----------
+    @requires_core_image_cloud_data
+    class TestSomething(TestCase):
+        ...
+
+    Test usage
+    ----------
+    @requires_core_image_cloud_data(ct_path=("CBCT", "CatPhan_504", ...))
+    def test_x(self, ct_path: str):
+        ...
+    """
+    if len(args) == 1 and isinstance(args[0], type):
+        return _decorate_core_cloud_test_class(args[0])
+
+    if args:
+        raise ValueError(
+            "Pass named cloud paths, e.g. @requires_core_image_cloud_data(ct_path=(...))."
+        )
+
+    if not kwargs:
+        raise ValueError("At least one named cloud path must be provided.")
+
+    normalized_paths = {name: list(path) for name, path in kwargs.items()}
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*func_args, **func_kwargs):
+            resolved = {
+                name: get_file_from_cloud_test_repo(path)
+                for name, path in normalized_paths.items()
+            }
+            return func(*func_args, **func_kwargs, **resolved)
+
+        return wrapper
+
+    return decorator
+
+
+@requires_core_image_cloud_data
 class TestFromMultiples(TestCase):
     def test_from_multiples(self):
         """Test that loading multiple images works"""
@@ -128,6 +220,7 @@ class TestFromMultiples(TestCase):
         self.assertEqual(np.max(img_cropped.array), 65535)  # max of uint16
 
 
+@requires_core_image_cloud_data
 class TestDICOMScaling(TestCase):
     def test_scale_raw_pixels_doesnt_change_array(self):
         """Test that loading a dicom with raw_pixels=True doesn't change the array"""
@@ -147,21 +240,21 @@ class TestDICOMScaling(TestCase):
         )
         assert np.array_equal(array, scaled_array)
 
-    def test_scale_mr_image(self):
+    @requires_core_image_cloud_data(mr_dcm=("ACR", "MRI", "GE - 3T", "IM_0001"))
+    def test_scale_mr_image(self, mr_dcm: str):
         """Test loading a dicom with MR storage without rescale slope or intercept tags"""
-        dcm_path = get_file_from_cloud_test_repo(["ACR", "MRI", "GE - 3T", "IM_0001"])
-        ds = pydicom.dcmread(dcm_path)
+        ds = pydicom.dcmread(mr_dcm)
         array = _rescale_dicom_values(
             ds.pixel_array, ds, raw_pixels=False, invert_pixels=None
         )
         assert np.array_equal(ds.pixel_array, array)
 
-    def test_scale_ct_image(self):
+    @requires_core_image_cloud_data(
+        ct_dcm=("CBCT", "CatPhan_504", "Case3_Philips_1mm", "1mm", "EE035381")
+    )
+    def test_scale_ct_image(self, ct_dcm: str):
         """Test loading a CT Image where we are guaranteed to have rescale slope and intercept tags"""
-        dcm_path = get_file_from_cloud_test_repo(
-            ["CBCT", "CatPhan_504", "Case3_Philips_1mm", "1mm", "EE035381"]
-        )
-        ds = pydicom.dcmread(dcm_path)
+        ds = pydicom.dcmread(ct_dcm)
         scaled_array = _rescale_dicom_values(
             ds.pixel_array, ds, raw_pixels=False, invert_pixels=None
         )
@@ -233,6 +326,7 @@ class TestDICOMScaling(TestCase):
         self.assertEqual(inverted_array[1], array[0])
 
 
+@requires_core_image_cloud_data
 class TestDICOMUnscaling(TestCase):
     def test_unscale_raw_pixels_doesnt_change_array(self):
         """Test when we unscale the image that the values are the same"""
@@ -252,20 +346,20 @@ class TestDICOMUnscaling(TestCase):
         )
         assert np.array_equal(original_array, scaled_array)
 
-    def test_unscale_mr_image(self):
-        dcm_path = get_file_from_cloud_test_repo(["ACR", "MRI", "GE - 3T", "IM_0001"])
-        ds = pydicom.dcmread(dcm_path)
+    @requires_core_image_cloud_data(mr_dcm=("ACR", "MRI", "GE - 3T", "IM_0001"))
+    def test_unscale_mr_image(self, mr_dcm: str):
+        ds = pydicom.dcmread(mr_dcm)
         array = _unscale_dicom_values(
             ds.pixel_array, ds, raw_pixels=False, invert_pixels=None
         )
         assert np.array_equal(ds.pixel_array, array)
 
-    def test_unscale_ct_image(self):
+    @requires_core_image_cloud_data(
+        ct_dcm=("CBCT", "CatPhan_504", "Case3_Philips_1mm", "1mm", "EE035381")
+    )
+    def test_unscale_ct_image(self, ct_dcm: str):
         """Test an older CT Image where we are guaranteed to have rescale slope and intercept tags"""
-        dcm_path = get_file_from_cloud_test_repo(
-            ["CBCT", "CatPhan_504", "Case3_Philips_1mm", "1mm", "EE035381"]
-        )
-        ds = pydicom.dcmread(dcm_path)
+        ds = pydicom.dcmread(ct_dcm)
         original_array = ds.pixel_array
         scaled_array = _rescale_dicom_values(
             ds.pixel_array, ds, raw_pixels=False, invert_pixels=None
@@ -322,6 +416,7 @@ class TestEquateImages(TestCase):
         self.assertEqual(img1.shape, img2.shape)
 
 
+@requires_core_image_cloud_data
 class TestLoaders(TestCase):
     """Test the image loading functions."""
 
@@ -413,6 +508,7 @@ class TestLoaders(TestCase):
         )
 
 
+@requires_core_image_cloud_data
 class TestBaseImage(TestCase):
     """Test the basic methods of BaseImage. Since it's a semi-abstract class, its subclasses (DicomImage,
     ArrayImage, and FileImage) are tested."""
@@ -599,6 +695,7 @@ class TestImageWindowHelpers(TestCase):
         plt.close(fig)
 
 
+@requires_core_image_cloud_data
 class TestDicomImage(TestCase):
     @classmethod
     def setUpClass(cls):
@@ -732,6 +829,7 @@ class TestDicomImage(TestCase):
         self.assertAlmostEqual(stack[1].slice_spacing, 2, places=1)
 
 
+@requires_core_image_cloud_data
 class TestXIMImage(TestCase):
     def test_normal_load(self):
         xim = XIM(xim_path)
@@ -807,6 +905,7 @@ class TestXIMImage(TestCase):
         self.assertEqual(xim.array.max(), 38822)
 
 
+@requires_core_image_cloud_data
 class TestLinacDicomImage(TestCase):
     def test_normal_image(self):
         img = LinacDicomImage(as500_path, use_filenames=False)
@@ -868,6 +967,7 @@ class TestLinacDicomImage(TestCase):
         self.assertEqual(img.couch_angle, 0)
 
 
+@requires_core_image_cloud_data
 class TestFileImage(TestCase):
     def test_sid(self):
         # default sid is None
@@ -907,6 +1007,7 @@ class TestFileImage(TestCase):
             fimg.dpi
 
 
+@requires_core_image_cloud_data
 class TestTiff(TestCase):
     """A special case of the FileImage"""
 
@@ -932,8 +1033,13 @@ class TestArrayImage(TestCase):
         self.assertEqual(ai2.dpmm, 20 / 25.4)
 
 
+@requires_core_image_cloud_data
 class TestDicomStack(TestCase):
-    stack_location = get_file_from_cloud_test_repo(["CBCT", "CBCT_4.zip"])
+    stack_location = ""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.stack_location = get_file_from_cloud_test_repo(["CBCT", "CBCT_4.zip"])
 
     def test_loading(self):
         # test normal construction
@@ -1020,6 +1126,7 @@ class TestDicomStack(TestCase):
         self.assertAlmostEqual(dstack.slice_spacing, 10, delta=0.001)
 
 
+@requires_core_image_cloud_data
 class TestRawImages(TestCase):
     def test_3d_shape_fails(self):
         """Test that a 3D array fails to load"""
@@ -1096,6 +1203,7 @@ class TestRawImages(TestCase):
         self.assertEqual(img.dpi, 100)
 
 
+@requires_core_image_cloud_data
 class TestTiffToDicom(TestCase):
     def test_conversion_can_be_loaded_as_dicom(self):
         ds = tiff_to_dicom(

--- a/tests_basic/core/test_image.py
+++ b/tests_basic/core/test_image.py
@@ -1,5 +1,4 @@
 import copy
-import functools
 import io
 import json
 import math
@@ -9,7 +8,6 @@ import tempfile
 import unittest
 import zipfile
 from builtins import ValueError
-from functools import lru_cache
 from pathlib import Path
 from unittest import TestCase
 
@@ -46,125 +44,35 @@ from pylinac.metrics.image import GlobalSizedFieldLocator
 from tests_basic.utils import (
     get_file_from_cloud_test_repo,
     get_folder_from_cloud_repo,
+    requires_cloud_data,
     save_file,
 )
 
-bad_tif_path = ""
-tif_path = ""
-png_path = ""
-dcm_path = ""
-as500_path = ""
-xim_path = ""
-xim_dcm_path = ""
 dcm_url = "https://storage.googleapis.com/pylinac_demo_files/EPID-PF-LR.dcm"
 
 
-@lru_cache(maxsize=1)
-def _resolve_core_image_cloud_paths() -> dict[str, str]:
-    return {
-        "bad_tif_path": get_file_from_cloud_test_repo(
-            ["Winston-Lutz", "AQA_A_03082023.tif"]
-        ),
-        "tif_path": get_file_from_cloud_test_repo(["Starshot", "Starshot-1.tif"]),
-        "png_path": get_file_from_cloud_test_repo(["Starshot", "Starshot-1.png"]),
-        "dcm_path": get_file_from_cloud_test_repo(["VMAT", "DRGSdmlc-105-example.dcm"]),
-        "as500_path": get_file_from_cloud_test_repo(["picket_fence", "AS500#5.dcm"]),
-        "xim_path": get_file_from_cloud_test_repo(["ximdcmtest.xim"]),
-        "xim_dcm_path": get_file_from_cloud_test_repo(["ximdcmtest.dcm"]),
+@requires_cloud_data(
+    files={
+        "dcm_path": ["VMAT", "DRGSdmlc-105-example.dcm"],
+        "tif_path": ["Starshot", "Starshot-1.tif"],
     }
-
-
-def _ensure_core_image_cloud_paths() -> None:
-    global \
-        as500_path, \
-        bad_tif_path, \
-        dcm_path, \
-        png_path, \
-        tif_path, \
-        xim_dcm_path, \
-        xim_path
-    paths = _resolve_core_image_cloud_paths()
-    bad_tif_path = paths["bad_tif_path"]
-    tif_path = paths["tif_path"]
-    png_path = paths["png_path"]
-    dcm_path = paths["dcm_path"]
-    as500_path = paths["as500_path"]
-    xim_path = paths["xim_path"]
-    xim_dcm_path = paths["xim_dcm_path"]
-
-
-def _decorate_core_cloud_test_class(cls: type[TestCase]) -> type[TestCase]:
-    original_set_up_class = getattr(cls, "setUpClass", None)
-
-    @classmethod
-    def set_up_class(inner_cls):
-        _ensure_core_image_cloud_paths()
-        if original_set_up_class is not None:
-            original_set_up_class()
-
-    cls.setUpClass = set_up_class
-    return cls
-
-
-def requires_core_image_cloud_data(*args, **kwargs):
-    """Decorator for class-level shared cloud paths or test-level specific files.
-
-    Class usage
-    -----------
-    @requires_core_image_cloud_data
-    class TestSomething(TestCase):
-        ...
-
-    Test usage
-    ----------
-    @requires_core_image_cloud_data(ct_path=("CBCT", "CatPhan_504", ...))
-    def test_x(self, ct_path: str):
-        ...
-    """
-    if len(args) == 1 and isinstance(args[0], type):
-        return _decorate_core_cloud_test_class(args[0])
-
-    if args:
-        raise ValueError(
-            "Pass named cloud paths, e.g. @requires_core_image_cloud_data(ct_path=(...))."
-        )
-
-    if not kwargs:
-        raise ValueError("At least one named cloud path must be provided.")
-
-    normalized_paths = {name: list(path) for name, path in kwargs.items()}
-
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*func_args, **func_kwargs):
-            resolved = {
-                name: get_file_from_cloud_test_repo(path)
-                for name, path in normalized_paths.items()
-            }
-            return func(*func_args, **func_kwargs, **resolved)
-
-        return wrapper
-
-    return decorator
-
-
-@requires_core_image_cloud_data
+)
 class TestFromMultiples(TestCase):
     def test_from_multiples(self):
         """Test that loading multiple images works"""
-        paths = [dcm_path, dcm_path, dcm_path]
+        paths = [self.dcm_path, self.dcm_path, self.dcm_path]
         img = image.load_multiples(paths)
         self.assertIsInstance(img, DicomImage)
 
     def test_different_sizes_fails(self):
         """Different-sized images can't be superimposed"""
-        paths = [dcm_path, tif_path]
+        paths = [self.dcm_path, self.tif_path]
         with self.assertRaises(ValueError):
             image.load_multiples(paths)
 
     def test_round_trip_via_temp_file(self):
         """Test that loading multiple images works"""
-        paths = [dcm_path, dcm_path]
+        paths = [self.dcm_path, self.dcm_path]
         img = image.load_multiples(paths)
         with tempfile.NamedTemporaryFile(delete=False) as tf:
             img.save(tf.name)
@@ -174,7 +82,7 @@ class TestFromMultiples(TestCase):
 
     def test_round_trip_via_stream(self):
         """Test that loading multiple images works"""
-        paths = [dcm_path, dcm_path]
+        paths = [self.dcm_path, self.dcm_path]
         img = image.load_multiples(paths)
         with io.BytesIO() as stream:
             img.save(stream)
@@ -185,19 +93,19 @@ class TestFromMultiples(TestCase):
 
     def test_max_stays_same(self):
         """Test the max value of the image stays the same when using max method"""
-        paths = [dcm_path, dcm_path]
+        paths = [self.dcm_path, self.dcm_path]
         img = image.load_multiples(paths, method="max", stretch_each=False)
-        self.assertEqual(np.max(image.load(dcm_path).array), np.max(img.array))
+        self.assertEqual(np.max(image.load(self.dcm_path).array), np.max(img.array))
 
     def test_max_goes_to_1_with_stretch(self):
         """Test the max value of the image goes to 1 when using max method and stretch"""
-        paths = [dcm_path, dcm_path]
+        paths = [self.dcm_path, self.dcm_path]
         img = image.load_multiples(paths, method="max", stretch_each=True)
         self.assertEqual(np.max(img.array), 1)
 
     def test_rescale_to_int16_max_stretch_true(self):
         """Test that loading multiple images works"""
-        paths = [dcm_path, dcm_path]
+        paths = [self.dcm_path, self.dcm_path]
         img = image.load_multiples(
             paths, stretch_each=True, method="max"
         )  # will cause a value >1
@@ -209,7 +117,7 @@ class TestFromMultiples(TestCase):
 
     def test_rescale_to_int16_max_stretch_false(self):
         """Test that loading multiple images works"""
-        paths = [dcm_path, dcm_path]
+        paths = [self.dcm_path, self.dcm_path]
         img = image.load_multiples(
             paths, stretch_each=False, method="max"
         )  # will still be a float array.
@@ -220,11 +128,11 @@ class TestFromMultiples(TestCase):
         self.assertEqual(np.max(img_cropped.array), 65535)  # max of uint16
 
 
-@requires_core_image_cloud_data
+@requires_cloud_data(files={"dcm_path": ["VMAT", "DRGSdmlc-105-example.dcm"]})
 class TestDICOMScaling(TestCase):
     def test_scale_raw_pixels_doesnt_change_array(self):
         """Test that loading a dicom with raw_pixels=True doesn't change the array"""
-        ds = pydicom.dcmread(dcm_path)
+        ds = pydicom.dcmread(self.dcm_path)
         array = _rescale_dicom_values(
             ds.pixel_array, ds, raw_pixels=True, invert_pixels=None
         )
@@ -240,7 +148,7 @@ class TestDICOMScaling(TestCase):
         )
         assert np.array_equal(array, scaled_array)
 
-    @requires_core_image_cloud_data(mr_dcm=("ACR", "MRI", "GE - 3T", "IM_0001"))
+    @requires_cloud_data(files={"mr_dcm": ["ACR", "MRI", "GE - 3T", "IM_0001"]})
     def test_scale_mr_image(self, mr_dcm: str):
         """Test loading a dicom with MR storage without rescale slope or intercept tags"""
         ds = pydicom.dcmread(mr_dcm)
@@ -249,8 +157,10 @@ class TestDICOMScaling(TestCase):
         )
         assert np.array_equal(ds.pixel_array, array)
 
-    @requires_core_image_cloud_data(
-        ct_dcm=("CBCT", "CatPhan_504", "Case3_Philips_1mm", "1mm", "EE035381")
+    @requires_cloud_data(
+        files={
+            "ct_dcm": ["CBCT", "CatPhan_504", "Case3_Philips_1mm", "1mm", "EE035381"]
+        }
     )
     def test_scale_ct_image(self, ct_dcm: str):
         """Test loading a CT Image where we are guaranteed to have rescale slope and intercept tags"""
@@ -326,11 +236,11 @@ class TestDICOMScaling(TestCase):
         self.assertEqual(inverted_array[1], array[0])
 
 
-@requires_core_image_cloud_data
+@requires_cloud_data(files={"dcm_path": ["VMAT", "DRGSdmlc-105-example.dcm"]})
 class TestDICOMUnscaling(TestCase):
     def test_unscale_raw_pixels_doesnt_change_array(self):
         """Test when we unscale the image that the values are the same"""
-        ds = pydicom.dcmread(dcm_path)
+        ds = pydicom.dcmread(self.dcm_path)
         array = _unscale_dicom_values(
             ds.pixel_array, ds, raw_pixels=True, invert_pixels=None
         )
@@ -346,7 +256,7 @@ class TestDICOMUnscaling(TestCase):
         )
         assert np.array_equal(original_array, scaled_array)
 
-    @requires_core_image_cloud_data(mr_dcm=("ACR", "MRI", "GE - 3T", "IM_0001"))
+    @requires_cloud_data(files={"mr_dcm": ["ACR", "MRI", "GE - 3T", "IM_0001"]})
     def test_unscale_mr_image(self, mr_dcm: str):
         ds = pydicom.dcmread(mr_dcm)
         array = _unscale_dicom_values(
@@ -354,8 +264,10 @@ class TestDICOMUnscaling(TestCase):
         )
         assert np.array_equal(ds.pixel_array, array)
 
-    @requires_core_image_cloud_data(
-        ct_dcm=("CBCT", "CatPhan_504", "Case3_Philips_1mm", "1mm", "EE035381")
+    @requires_cloud_data(
+        files={
+            "ct_dcm": ["CBCT", "CatPhan_504", "Case3_Philips_1mm", "1mm", "EE035381"]
+        }
     )
     def test_unscale_ct_image(self, ct_dcm: str):
         """Test an older CT Image where we are guaranteed to have rescale slope and intercept tags"""
@@ -416,7 +328,12 @@ class TestEquateImages(TestCase):
         self.assertEqual(img1.shape, img2.shape)
 
 
-@requires_core_image_cloud_data
+@requires_cloud_data(
+    files={
+        "dcm_path": ["VMAT", "DRGSdmlc-105-example.dcm"],
+        "tif_path": ["Starshot", "Starshot-1.tif"],
+    }
+)
 class TestLoaders(TestCase):
     """Test the image loading functions."""
 
@@ -425,31 +342,31 @@ class TestLoaders(TestCase):
         self.assertIsInstance(img, DicomImage)
 
     def test_load_dicom(self):
-        img = image.load(dcm_path)
+        img = image.load(self.dcm_path)
         self.assertIsInstance(img, DicomImage)
 
     def test_load_dicom_from_stream(self):
-        img_ref = image.load(dcm_path)
-        with open(dcm_path, "rb") as f:
+        img_ref = image.load(self.dcm_path)
+        with open(self.dcm_path, "rb") as f:
             p = io.BytesIO(f.read())
             img = image.load(p)
         self.assertIsInstance(img, DicomImage)
         self.assertEqual(img.dpi, img_ref.dpi)
 
     def test_load_dicom_from_file_object(self):
-        img_ref = image.load(dcm_path)
-        with open(dcm_path, "rb") as f:
+        img_ref = image.load(self.dcm_path)
+        with open(self.dcm_path, "rb") as f:
             img = image.load(f)
         self.assertIsInstance(img, DicomImage)
         self.assertEqual(img.dpi, img_ref.dpi)
 
     def test_load_file(self):
-        img = image.load(tif_path)
+        img = image.load(self.tif_path)
         self.assertIsInstance(img, FileImage)
 
     def test_load_file_from_stream(self):
-        img_ref = image.load(tif_path)
-        with open(tif_path, "rb") as f:
+        img_ref = image.load(self.tif_path)
+        with open(self.tif_path, "rb") as f:
             p = io.BytesIO(f.read())
             img = image.load(p)
         self.assertIsInstance(img, FileImage)
@@ -457,9 +374,9 @@ class TestLoaders(TestCase):
         self.assertEqual(img.center, img_ref.center)
 
     def test_load_file_from_temp_file(self):
-        img_ref = image.load(tif_path)
+        img_ref = image.load(self.tif_path)
         tmp = tempfile.NamedTemporaryFile(delete=False)
-        tmp.write(open(tif_path, "rb").read())
+        tmp.write(open(self.tif_path, "rb").read())
         img = image.load(tmp)
         self.assertIsInstance(img, FileImage)
         self.assertIsInstance(img.path, str)
@@ -467,8 +384,8 @@ class TestLoaders(TestCase):
         self.assertEqual(img.center, img_ref.center)
 
     def test_load_file_from_file_object(self):
-        img_ref = image.load(tif_path)
-        with open(tif_path, "rb") as f:
+        img_ref = image.load(self.tif_path)
+        with open(self.tif_path, "rb") as f:
             img = image.load(f)
         self.assertIsInstance(img, FileImage)
         self.assertEqual(img.center, img_ref.center)
@@ -479,18 +396,18 @@ class TestLoaders(TestCase):
         self.assertIsInstance(img, ArrayImage)
 
     def test_load_multiples(self):
-        paths = [dcm_path, dcm_path, dcm_path]
+        paths = [self.dcm_path, self.dcm_path, self.dcm_path]
         img = image.load_multiples(paths)
         self.assertIsInstance(img, DicomImage)
 
         # test non-superimposable images
-        paths = [dcm_path, tif_path]
+        paths = [self.dcm_path, self.tif_path]
         with self.assertRaises(ValueError):
             image.load_multiples(paths)
 
     def test_load_multiples_custom_loader(self):
         """Use a custom loader to load multiple images"""
-        paths = [dcm_path, dcm_path, dcm_path]
+        paths = [self.dcm_path, self.dcm_path, self.dcm_path]
         img = image.load_multiples(paths, loader=image.LinacDicomImage)
         self.assertIsInstance(img, image.LinacDicomImage)
 
@@ -499,7 +416,7 @@ class TestLoaders(TestCase):
             image.load("blahblah")
 
     def test_is_image(self):
-        self.assertTrue(image.is_image(dcm_path))
+        self.assertTrue(image.is_image(self.dcm_path))
         # not an image
         self.assertFalse(
             image.is_image(
@@ -508,14 +425,19 @@ class TestLoaders(TestCase):
         )
 
 
-@requires_core_image_cloud_data
+@requires_cloud_data(
+    files={
+        "dcm_path": ["VMAT", "DRGSdmlc-105-example.dcm"],
+        "tif_path": ["Starshot", "Starshot-1.tif"],
+    }
+)
 class TestBaseImage(TestCase):
     """Test the basic methods of BaseImage. Since it's a semi-abstract class, its subclasses (DicomImage,
     ArrayImage, and FileImage) are tested."""
 
     def setUp(self):
-        self.img = image.load(tif_path)
-        self.dcm = image.load(dcm_path)
+        self.img = image.load(self.tif_path)
+        self.dcm = image.load(self.dcm_path)
         array = np.arange(42).reshape(6, 7)
         self.arr = image.load(array)
 
@@ -695,11 +617,11 @@ class TestImageWindowHelpers(TestCase):
         plt.close(fig)
 
 
-@requires_core_image_cloud_data
+@requires_cloud_data(files={"dcm_path": ["VMAT", "DRGSdmlc-105-example.dcm"]})
 class TestDicomImage(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.dcm: DicomImage = image.load(dcm_path)
+        cls.dcm: DicomImage = image.load(cls.dcm_path)
 
     def test_sid(self):
         self.assertEqual(self.dcm.sid, 1050)
@@ -723,7 +645,7 @@ class TestDicomImage(TestCase):
     def test_cax_returns_center_when_sid_is_missing(self):
         # RAM-5787: missing RTImageSID tag causes self.sid to be None,
         # which previously raised TypeError before the try/except could catch it.
-        ds = pydicom.dcmread(dcm_path)
+        ds = pydicom.dcmread(self.dcm_path)
         del ds.RTImageSID
         img = DicomImage.from_dataset(ds)
         self.assertEqual(img.cax, img.center)
@@ -732,8 +654,8 @@ class TestDicomImage(TestCase):
         save_file(self.dcm.save)
 
     def test_save_round_trip_has_same_pixel_values(self):
-        original_dcm = pydicom.dcmread(dcm_path)
-        dcm_img = DicomImage(dcm_path)
+        original_dcm = pydicom.dcmread(self.dcm_path)
+        dcm_img = DicomImage(self.dcm_path)
         with io.BytesIO() as stream:
             dcm_img.save(stream)
             stream.seek(0)
@@ -753,8 +675,8 @@ class TestDicomImage(TestCase):
     def test_save_out_of_bounds_values_normalizes(self):
         # this occurs if we add multiple images together and the values go out of bounds
         # causing a bit overflow
-        original_dcm = pydicom.dcmread(dcm_path)
-        dcm_img = DicomImage(dcm_path)
+        original_dcm = pydicom.dcmread(self.dcm_path)
+        dcm_img = DicomImage(self.dcm_path)
         dcm_img.array *= 10e6  # values out of normal bounds of uint16
         with io.BytesIO() as stream, self.assertWarns(UserWarning):
             dcm_img.save(stream)
@@ -770,7 +692,7 @@ class TestDicomImage(TestCase):
         )
 
     def test_manipulation_still_saves_correctly(self):
-        dcm = image.load(dcm_path)
+        dcm = image.load(self.dcm_path)
         original_shape = dcm.shape
         dcm.crop(15)
         with tempfile.NamedTemporaryFile(delete=False) as tf:
@@ -785,11 +707,11 @@ class TestDicomImage(TestCase):
         )  # 15 from each side = 2 * 15 = 30
 
     def test_raw_pixels_via_load(self):
-        dcm_ds = pydicom.dcmread(dcm_path)
-        dcm_raw = image.load(dcm_path, raw_pixels=True)
+        dcm_ds = pydicom.dcmread(self.dcm_path)
+        dcm_raw = image.load(self.dcm_path, raw_pixels=True)
         assert np.array_equal(dcm_raw.array, dcm_ds.pixel_array)
         # test that the pixels are corrected otherwise
-        dcm_corr = image.load(dcm_path)
+        dcm_corr = image.load(self.dcm_path)
         assert not np.array_equal(dcm_corr.array, dcm_ds.pixel_array)
 
     def test_z_location_mri(self):
@@ -829,10 +751,15 @@ class TestDicomImage(TestCase):
         self.assertAlmostEqual(stack[1].slice_spacing, 2, places=1)
 
 
-@requires_core_image_cloud_data
+@requires_cloud_data(
+    files={
+        "xim_path": ["ximdcmtest.xim"],
+        "xim_dcm_path": ["ximdcmtest.dcm"],
+    }
+)
 class TestXIMImage(TestCase):
     def test_normal_load(self):
-        xim = XIM(xim_path)
+        xim = XIM(self.xim_path)
         self.assertIsInstance(xim.array, np.ndarray)
         self.assertEqual(xim.array.shape, (1280, 1280))
         self.assertIsInstance(xim.properties, dict)
@@ -845,19 +772,19 @@ class TestXIMImage(TestCase):
         XIM(get_file_from_cloud_test_repo(["xim_2byte_diff.xim"]))
 
     def test_dont_read_pixels(self):
-        xim = XIM(xim_path, read_pixels=False)
+        xim = XIM(self.xim_path, read_pixels=False)
         with self.assertRaises(AttributeError):
             xim.array
         self.assertIsInstance(xim.properties, dict)
 
     def test_equivalent_to_dcm(self):
         """The pixel info should be the same between dicom and xim"""
-        dcm_img = DicomImage(xim_dcm_path)
-        xim_img = XIM(xim_path)
+        dcm_img = DicomImage(self.xim_dcm_path)
+        xim_img = XIM(self.xim_path)
         assert_array_almost_equal(dcm_img.array, xim_img.array)
 
     def test_save_png_stream(self):
-        xim = XIM(xim_path)
+        xim = XIM(self.xim_path)
         s = io.BytesIO()
         xim.save_as(s, format="png")
         s.seek(0)
@@ -866,7 +793,7 @@ class TestXIMImage(TestCase):
         assert_array_almost_equal(png_array, xim.array)
 
     def test_save_png(self):
-        xim = XIM(xim_path)
+        xim = XIM(self.xim_path)
         with tempfile.NamedTemporaryFile(delete=False) as tf:
             xim.save_as(tf, format="png")
             pimg = PIL.Image.open(tf.name)
@@ -881,7 +808,7 @@ class TestXIMImage(TestCase):
         self.assertIsInstance(mlc_a, list)
 
     def test_save_tiff(self):
-        xim = XIM(xim_path)
+        xim = XIM(self.xim_path)
         with tempfile.NamedTemporaryFile(delete=False) as tf:
             xim.save_as(tf, format="tiff")
             pimg = PIL.Image.open(tf.name)
@@ -905,15 +832,15 @@ class TestXIMImage(TestCase):
         self.assertEqual(xim.array.max(), 38822)
 
 
-@requires_core_image_cloud_data
+@requires_cloud_data(files={"as500_path": ["picket_fence", "AS500#5.dcm"]})
 class TestLinacDicomImage(TestCase):
     def test_normal_image(self):
-        img = LinacDicomImage(as500_path, use_filenames=False)
+        img = LinacDicomImage(self.as500_path, use_filenames=False)
         self.assertEqual(img.gantry_angle, 0)
 
     def test_passing_axis_info_through_filename(self):
-        new_name = as500_path.replace("AS500#5", "AS500Gantry78Coll13Couch44")
-        shutil.copy(as500_path, new_name)
+        new_name = self.as500_path.replace("AS500#5", "AS500Gantry78Coll13Couch44")
+        shutil.copy(self.as500_path, new_name)
         img = LinacDicomImage(new_name, use_filenames=True)
         self.assertEqual(img.gantry_angle, 78)
         self.assertEqual(img.collimator_angle, 13)
@@ -921,7 +848,7 @@ class TestLinacDicomImage(TestCase):
 
     def test_passing_axis_info_directly(self):
         img = LinacDicomImage(
-            as500_path, use_filenames=False, gantry=24, coll=60, couch=8
+            self.as500_path, use_filenames=False, gantry=24, coll=60, couch=8
         )
         self.assertEqual(img.gantry_angle, 24)
         self.assertEqual(img.collimator_angle, 60)
@@ -929,7 +856,7 @@ class TestLinacDicomImage(TestCase):
 
     def test_using_axes_no_precision_doesnt_round(self):
         img = LinacDicomImage(
-            as500_path,
+            self.as500_path,
             use_filenames=False,
             axes_precision=None,
             gantry=0.12345,
@@ -942,7 +869,7 @@ class TestLinacDicomImage(TestCase):
 
     def test_using_axes_2precision(self):
         img = LinacDicomImage(
-            as500_path,
+            self.as500_path,
             use_filenames=False,
             axes_precision=2,
             gantry=0.12345,
@@ -955,7 +882,7 @@ class TestLinacDicomImage(TestCase):
 
     def test_using_axes_0precision(self):
         img = LinacDicomImage(
-            as500_path,
+            self.as500_path,
             use_filenames=False,
             axes_precision=0,
             gantry=0.12345,
@@ -967,15 +894,21 @@ class TestLinacDicomImage(TestCase):
         self.assertEqual(img.couch_angle, 0)
 
 
-@requires_core_image_cloud_data
+@requires_cloud_data(
+    files={
+        "tif_path": ["Starshot", "Starshot-1.tif"],
+        "png_path": ["Starshot", "Starshot-1.png"],
+        "bad_tif_path": ["Winston-Lutz", "AQA_A_03082023.tif"],
+    }
+)
 class TestFileImage(TestCase):
     def test_sid(self):
         # default sid is None
-        fi = FileImage(tif_path)
+        fi = FileImage(self.tif_path)
         self.assertIsNone(fi.sid)
 
         # SID can be set though
-        fi2 = FileImage(tif_path, sid=1500)
+        fi2 = FileImage(self.tif_path, sid=1500)
         self.assertEqual(fi2.sid, 1500)
 
         # SID also affects the dpi
@@ -985,29 +918,28 @@ class TestFileImage(TestCase):
 
     def test_dpi_dpmm(self):
         # DPI is usually in TIF files
-        fi = FileImage(tif_path)
+        fi = FileImage(self.tif_path)
         # shouldn't raise
         fi.dpi
         fi.dpmm
 
         # not in certain other files
-        fi_jpg = FileImage(png_path)
+        fi_jpg = FileImage(self.png_path)
         self.assertIsNone(fi_jpg.dpi)
 
         # but DPI can be set though
-        fi_jpg2 = FileImage(png_path, dpi=100)
+        fi_jpg2 = FileImage(self.png_path, dpi=100)
         # shouldn't raise
         fi_jpg2.dpi
         fi_jpg2.dpmm
 
     def test_dpi_abnormal(self):
         # has DPI of 1. Nonsensical
-        fimg = FileImage(bad_tif_path)
+        fimg = FileImage(self.bad_tif_path)
         with self.assertRaises(ValueError):
             fimg.dpi
 
 
-@requires_core_image_cloud_data
 class TestTiff(TestCase):
     """A special case of the FileImage"""
 
@@ -1033,14 +965,8 @@ class TestArrayImage(TestCase):
         self.assertEqual(ai2.dpmm, 20 / 25.4)
 
 
-@requires_core_image_cloud_data
+@requires_cloud_data(files={"stack_location": ["CBCT", "CBCT_4.zip"]})
 class TestDicomStack(TestCase):
-    stack_location = ""
-
-    @classmethod
-    def setUpClass(cls):
-        cls.stack_location = get_file_from_cloud_test_repo(["CBCT", "CBCT_4.zip"])
-
     def test_loading(self):
         # test normal construction
         with TemporaryZipDirectory(self.stack_location) as tmpzip:
@@ -1126,7 +1052,6 @@ class TestDicomStack(TestCase):
         self.assertAlmostEqual(dstack.slice_spacing, 10, delta=0.001)
 
 
-@requires_core_image_cloud_data
 class TestRawImages(TestCase):
     def test_3d_shape_fails(self):
         """Test that a 3D array fails to load"""
@@ -1203,11 +1128,11 @@ class TestRawImages(TestCase):
         self.assertEqual(img.dpi, 100)
 
 
-@requires_core_image_cloud_data
+@requires_cloud_data(files={"tif_path": ["Starshot", "Starshot-1.tif"]})
 class TestTiffToDicom(TestCase):
     def test_conversion_can_be_loaded_as_dicom(self):
         ds = tiff_to_dicom(
-            tif_path,
+            self.tif_path,
             sid=1000,
             dpi=200,
             gantry=10,
@@ -1219,7 +1144,7 @@ class TestTiffToDicom(TestCase):
 
     def test_conversion_captures_axes(self):
         ds = tiff_to_dicom(
-            tif_path,
+            self.tif_path,
             sid=1000,
             dpi=200,
             gantry=10,
@@ -1232,15 +1157,15 @@ class TestTiffToDicom(TestCase):
         self.assertEqual(dicom_img.couch_angle, 33)
 
     def test_conversion_of_dpmm(self):
-        ds = tiff_to_dicom(tif_path, sid=1000, gantry=10, coll=22, couch=33)
+        ds = tiff_to_dicom(self.tif_path, sid=1000, gantry=10, coll=22, couch=33)
         dicom_img = LinacDicomImage.from_dataset(ds)
         self.assertEqual(dicom_img.dpi, 150)
         self.assertEqual(dicom_img.dpmm, 150 / 25.4)
 
     def test_conversion_keeps_datatype(self):
-        tiff_img = FileImage(tif_path)
+        tiff_img = FileImage(self.tif_path)
         ds = tiff_to_dicom(
-            tif_path,
+            self.tif_path,
             sid=1000,
             dpi=200,
             gantry=10,

--- a/tests_basic/core/test_utilities.py
+++ b/tests_basic/core/test_utilities.py
@@ -1,9 +1,11 @@
 import json
+import os
 import tempfile
 import unittest
 from builtins import AttributeError
 from pathlib import Path
 from unittest import TestCase
+from unittest.mock import patch
 
 import numpy as np
 import quaac
@@ -20,6 +22,7 @@ from pylinac.core.utilities import (
     simple_round,
     uniquify,
 )
+from tests_basic import utils as test_utils
 
 performer = User(name="James Kerns", email="j@j.com")
 linac = Equipment(
@@ -284,3 +287,42 @@ class TestUniquifyFunction(unittest.TestCase):
     def test_uniquify(self, name, existing, input_name, expected):
         result = uniquify(existing, input_name)
         self.assertEqual(result, expected)
+
+
+class TestCloudDataHelpers(unittest.TestCase):
+    def test_can_run_cloud_tests_false_when_env_is_set(self):
+        old_value = os.environ.get("PYLINAC_SKIP_CLOUD_TESTS")
+        try:
+            os.environ["PYLINAC_SKIP_CLOUD_TESTS"] = "1"
+            self.assertFalse(test_utils.can_run_cloud_tests())
+        finally:
+            if old_value is None:
+                os.environ.pop("PYLINAC_SKIP_CLOUD_TESTS", None)
+            else:
+                os.environ["PYLINAC_SKIP_CLOUD_TESTS"] = old_value
+
+    def test_get_file_from_cloud_test_repo_uses_cache(self):
+        path = ["folder", "file.dcm"]
+        test_utils._cached_file_from_cloud_test_repo.cache_clear()
+        with (
+            patch(
+                "tests_basic.utils._download_file_from_cloud_test_repo",
+                return_value="x",
+            ) as mocked_download,
+            patch("tests_basic.utils.can_run_cloud_tests", return_value=True),
+        ):
+            first = test_utils.get_file_from_cloud_test_repo(path)
+            second = test_utils.get_file_from_cloud_test_repo(path)
+            self.assertEqual(first, second)
+            mocked_download.assert_called_once_with(
+                path=("folder", "file.dcm"), force=False
+            )
+
+    def test_cloud_downloader_auth_property_is_cached(self):
+        downloader = test_utils.CloudTestDataDownloader()
+        with patch.object(
+            downloader, "_compute_authentication_status", return_value=True
+        ) as mocked_compute:
+            self.assertTrue(downloader.is_authenticated)
+            self.assertTrue(downloader.is_authenticated)
+            mocked_compute.assert_called_once()

--- a/tests_basic/test_acr.py
+++ b/tests_basic/test_acr.py
@@ -18,16 +18,12 @@ from tests_basic.utils import (
     FromZipTesterMixin,
     InitTesterMixin,
     PlotlyTestMixin,
-    get_file_from_cloud_test_repo,
-    get_folder_from_cloud_repo,
+    requires_cloud_data,
     save_file,
 )
 
 TEST_DIR_CT = ["ACR", "CT"]
 TEST_DIR_MR = ["ACR", "MRI"]
-
-get_folder_from_cloud_repo(TEST_DIR_CT)
-get_folder_from_cloud_repo(TEST_DIR_MR)
 
 
 class TestACRCT(TestCase, FromZipTesterMixin, InitTesterMixin):
@@ -36,23 +32,26 @@ class TestACRCT(TestCase, FromZipTesterMixin, InitTesterMixin):
     init_file = [*TEST_DIR_CT, "Philips_CT"]
     is_folder = True
 
-    def test_load_from_list_of_paths(self):
+    @requires_cloud_data(files={"ct_zip": [*TEST_DIR_CT, "Philips.zip"]})
+    def test_load_from_list_of_paths(self, ct_zip: str):
         # shouldn't raise
-        with TemporaryZipDirectory(get_file_from_cloud_test_repo(self.zip)) as zfolder:
+        with TemporaryZipDirectory(ct_zip) as zfolder:
             paths = [Path(zfolder) / f for f in os.listdir(zfolder)]
             ACRCT(paths)
 
-    def test_load_from_list_of_streams(self):
+    @requires_cloud_data(files={"ct_zip": [*TEST_DIR_CT, "Philips.zip"]})
+    def test_load_from_list_of_streams(self, ct_zip: str):
         # shouldn't raise
-        with TemporaryZipDirectory(get_file_from_cloud_test_repo(self.zip)) as zfolder:
+        with TemporaryZipDirectory(ct_zip) as zfolder:
             paths = [Path(zfolder, f) for f in os.listdir(zfolder)]
             paths = [io.BytesIO(open(p, "rb").read()) for p in paths]
             ACRCT(paths)
 
 
 class TestCTGeneral(TestCase):
-    def setUp(self):
-        self.path = get_file_from_cloud_test_repo([*TEST_DIR_CT, "Philips.zip"])
+    @requires_cloud_data(files={"ct_zip": [*TEST_DIR_CT, "Philips.zip"]})
+    def setUp(self, ct_zip: str):
+        self.path = ct_zip
         self.ct = ACRCT.from_zip(self.path)
 
     def test_phan_center(self):
@@ -101,9 +100,9 @@ class TestCTGeneral(TestCase):
 
 class TestPlottingSaving(TestCase):
     @classmethod
-    def setUpClass(cls):
-        path = get_file_from_cloud_test_repo([*TEST_DIR_CT, "Philips.zip"])
-        cls.ct = ACRCT.from_zip(path)
+    @requires_cloud_data(files={"ct_zip": [*TEST_DIR_CT, "Philips.zip"]})
+    def setUpClass(cls, ct_zip: str):
+        cls.ct = ACRCT.from_zip(ct_zip)
         cls.ct.analyze()
 
     @classmethod
@@ -344,22 +343,24 @@ class TestACRMRI(TestCase, FromZipTesterMixin, InitTesterMixin):
     init_file = [*TEST_DIR_MR, "GE - 3T"]
     is_folder = True
 
-    def test_load_from_list_of_paths(self):
+    @requires_cloud_data(files={"mr_zip": [*TEST_DIR_MR, "GE 3T.zip"]})
+    def test_load_from_list_of_paths(self, mr_zip: str):
         # shouldn't raise
-        with TemporaryZipDirectory(get_file_from_cloud_test_repo(self.zip)) as zfolder:
+        with TemporaryZipDirectory(mr_zip) as zfolder:
             paths = [Path(zfolder) / f for f in os.listdir(zfolder)]
             ACRMRILarge(paths)
 
-    def test_load_from_list_of_streams(self):
+    @requires_cloud_data(files={"mr_zip": [*TEST_DIR_MR, "GE 3T.zip"]})
+    def test_load_from_list_of_streams(self, mr_zip: str):
         # shouldn't raise
-        with TemporaryZipDirectory(get_file_from_cloud_test_repo(self.zip)) as zfolder:
+        with TemporaryZipDirectory(mr_zip) as zfolder:
             paths = [Path(zfolder, f) for f in os.listdir(zfolder)]
             paths = [io.BytesIO(open(p, "rb").read()) for p in paths]
             ACRMRILarge(paths)
 
-    def test_geometric_distortion_profile_lengths(self):
-        path = get_file_from_cloud_test_repo([*TEST_DIR_MR, "GE 3T.zip"])
-        mri = ACRMRILarge.from_zip(path)
+    @requires_cloud_data(files={"mr_zip": [*TEST_DIR_MR, "GE 3T.zip"]})
+    def test_geometric_distortion_profile_lengths(self, mr_zip: str):
+        mri = ACRMRILarge.from_zip(mr_zip)
         mri.analyze()
         data = mri.results_data()
         self.assertAlmostEqual(
@@ -389,9 +390,9 @@ class TestACRMRI(TestCase, FromZipTesterMixin, InitTesterMixin):
 
 
 class TestACRMRIResultData(TestCase, ResultsDataBase):
-    def construct_analyzed_instance(self):
-        path = get_file_from_cloud_test_repo([*TEST_DIR_MR, "GE 3T.zip"])
-        mri = ACRMRILarge.from_zip(path)
+    @requires_cloud_data(files={"mr_zip": [*TEST_DIR_MR, "GE 3T.zip"]})
+    def construct_analyzed_instance(self, mr_zip: str):
+        mri = ACRMRILarge.from_zip(mr_zip)
         mri.analyze()
         return mri
 
@@ -409,9 +410,9 @@ class TestACRMRIResultData(TestCase, ResultsDataBase):
 
 
 class TestMRGeneral(TestCase):
-    def setUp(self):
-        path = get_file_from_cloud_test_repo([*TEST_DIR_MR, "GE 3T.zip"])
-        self.mri = ACRMRILarge.from_zip(path)
+    @requires_cloud_data(files={"mr_zip": [*TEST_DIR_MR, "GE 3T.zip"]})
+    def setUp(self, mr_zip: str):
+        self.mri = ACRMRILarge.from_zip(mr_zip)
 
     def test_phan_center(self):
         """Test locations of the phantom center."""
@@ -441,35 +442,36 @@ class TestMRGeneral(TestCase):
             self.assertIn("message", w)
             self.assertIn("category", w)
 
-    def test_echo_number(self):
+    @requires_cloud_data(files={"dual_echo_zip": [*TEST_DIR_MR, "AXIAL_DUAL_ECHO.zip"]})
+    def test_echo_number(self, dual_echo_zip: str):
         """Test analyzing a specific echo number works"""
-        path = get_file_from_cloud_test_repo([*TEST_DIR_MR, "AXIAL_DUAL_ECHO.zip"])
-        mri1 = ACRMRILarge.from_zip(path)
+        mri1 = ACRMRILarge.from_zip(dual_echo_zip)
         mri1.analyze(echo_number=1)
         echo_number_1 = mri1.dicom_stack[0].metadata.EchoNumbers
-        path = get_file_from_cloud_test_repo([*TEST_DIR_MR, "AXIAL_DUAL_ECHO.zip"])
-        mri2 = ACRMRILarge.from_zip(path)
+        mri2 = ACRMRILarge.from_zip(dual_echo_zip)
         mri2.analyze(echo_number=2)
         echo_number_2 = mri2.dicom_stack[0].metadata.EchoNumbers
         self.assertNotEqual(echo_number_1, echo_number_2)
 
-    def test_echo_number_invalid(self):
-        path = get_file_from_cloud_test_repo([*TEST_DIR_MR, "AXIAL_DUAL_ECHO.zip"])
-        mri = ACRMRILarge.from_zip(path)
+    @requires_cloud_data(files={"dual_echo_zip": [*TEST_DIR_MR, "AXIAL_DUAL_ECHO.zip"]})
+    def test_echo_number_invalid(self, dual_echo_zip: str):
+        mri = ACRMRILarge.from_zip(dual_echo_zip)
         with self.assertRaises(ValueError):
             mri.analyze(echo_number=3)  # only 2 echoes
 
-    def test_echo_number_defaults_to_first(self):
-        path = get_file_from_cloud_test_repo([*TEST_DIR_MR, "AXIAL_DUAL_ECHO.zip"])
-        mri = ACRMRILarge.from_zip(path)
+    @requires_cloud_data(files={"dual_echo_zip": [*TEST_DIR_MR, "AXIAL_DUAL_ECHO.zip"]})
+    def test_echo_number_defaults_to_first(self, dual_echo_zip: str):
+        mri = ACRMRILarge.from_zip(dual_echo_zip)
         self.assertEqual(len({s.metadata.EchoNumbers for s in mri.dicom_stack}), 2)
         mri.analyze(echo_number=None)
         self.assertEqual(mri.dicom_stack[0].metadata.EchoNumbers, "1")
 
-    def test_config_extent_rounds(self):
+    @requires_cloud_data(
+        files={"config_rounding_zip": [*TEST_DIR_MR, "Config rounding.zip"]}
+    )
+    def test_config_extent_rounds(self, config_rounding_zip: str):
         """Test that the extent check rounds the config extent to the nearest slice"""
-        path = get_file_from_cloud_test_repo([*TEST_DIR_MR, "Config rounding.zip"])
-        mri = ACRMRILarge.from_zip(path)
+        mri = ACRMRILarge.from_zip(config_rounding_zip)
         self.assertTrue(mri._ensure_physical_scan_extent())
 
     def test_error_if_from_demo(self):
@@ -479,9 +481,9 @@ class TestMRGeneral(TestCase):
 
 class TestMRPlottingSaving(TestCase):
     @classmethod
-    def setUpClass(cls):
-        path = get_file_from_cloud_test_repo([*TEST_DIR_MR, "GE 3T.zip"])
-        cls.mri = ACRMRILarge.from_zip(path)
+    @requires_cloud_data(files={"mr_zip": [*TEST_DIR_MR, "GE 3T.zip"]})
+    def setUpClass(cls, mr_zip: str):
+        cls.mri = ACRMRILarge.from_zip(mr_zip)
         cls.mri.analyze()
 
     @classmethod

--- a/tests_basic/test_dlg.py
+++ b/tests_basic/test_dlg.py
@@ -2,13 +2,12 @@ import unittest
 
 from pylinac.dlg import DLG
 from pylinac.picketfence import MLC
-from tests_basic.utils import get_file_from_cloud_test_repo
+from tests_basic.utils import requires_cloud_data
 
 
 class TestDLG(unittest.TestCase):
-    file_path = get_file_from_cloud_test_repo(["DLG_1.5_0.2.dcm"])
-
-    def test_measured_dlg(self):
-        dlg = DLG(self.file_path)
+    @requires_cloud_data(files={"file_path": ["DLG_1.5_0.2.dcm"]})
+    def test_measured_dlg(self, file_path: str):
+        dlg = DLG(file_path)
         dlg.analyze(gaps=(-0.9, -1.1, -1.3, -1.5, -1.7, -1.9), mlc=MLC.MILLENNIUM)
         self.assertAlmostEqual(dlg.measured_dlg, 1.503, delta=0.001)

--- a/tests_basic/test_field_analysis.py
+++ b/tests_basic/test_field_analysis.py
@@ -29,8 +29,8 @@ from pylinac.field_analysis import (
 from tests_basic.core.test_utilities import QuaacTestBase, ResultsDataBase
 from tests_basic.utils import (
     CloudFileMixin,
-    get_file_from_cloud_test_repo,
     has_www_connection,
+    requires_cloud_data,
     save_file,
 )
 
@@ -51,8 +51,8 @@ class FieldAnalysisTests(QuaacTestBase, TestCase):
     def quaac_instance(self):
         return create_instance()
 
-    def test_load_from_file_object(self):
-        path = get_file_from_cloud_test_repo([TEST_DIR, "6x-auto-bulb-2.dcm"])
+    @requires_cloud_data(files={"path": [TEST_DIR, "6x-auto-bulb-2.dcm"]})
+    def test_load_from_file_object(self, path: str):
         ref_fa = FieldAnalysis(path)
         ref_fa.analyze()
         with open(path, "rb") as f:
@@ -61,8 +61,8 @@ class FieldAnalysisTests(QuaacTestBase, TestCase):
         self.assertIsInstance(fa, FieldAnalysis)
         self.assertEqual(fa.image.shape, ref_fa.image.shape)
 
-    def test_load_from_stream(self):
-        path = get_file_from_cloud_test_repo([TEST_DIR, "6x-auto-bulb-2.dcm"])
+    @requires_cloud_data(files={"path": [TEST_DIR, "6x-auto-bulb-2.dcm"]})
+    def test_load_from_stream(self, path: str):
         ref_fa = FieldAnalysis(path)
         ref_fa.analyze()
         with open(path, "rb") as f:
@@ -229,8 +229,8 @@ class FieldAnalysisTests(QuaacTestBase, TestCase):
         with self.assertRaises(ValueError):
             fa.analyze(interpolation="limmerick")
 
-    def test_image_kwargs(self):
-        path = get_file_from_cloud_test_repo([TEST_DIR, "6x-auto-bulb-2.dcm"])
+    @requires_cloud_data(files={"path": [TEST_DIR, "6x-auto-bulb-2.dcm"]})
+    def test_image_kwargs(self, path: str):
 
         ref_fa = FieldAnalysis(path)
         ref_fa.analyze()

--- a/tests_basic/test_field_profile_analysis.py
+++ b/tests_basic/test_field_profile_analysis.py
@@ -25,8 +25,8 @@ from pylinac.metrics.profile import (
 )
 from tests_basic.utils import (
     CloudFileMixin,
-    get_file_from_cloud_test_repo,
     has_www_connection,
+    requires_cloud_data,
     save_file,
 )
 
@@ -248,8 +248,8 @@ class FieldAnalysisTests(TestCase):
     def tearDown(self) -> None:
         plt.close("all")
 
-    def test_load_from_file_object(self):
-        path = get_file_from_cloud_test_repo([TEST_DIR, "6x-auto-bulb-2.dcm"])
+    @requires_cloud_data(files={"path": [TEST_DIR, "6x-auto-bulb-2.dcm"]})
+    def test_load_from_file_object(self, path: str):
         ref_fa = FieldProfileAnalysis(path)
         ref_fa.analyze()
         with open(path, "rb") as f:
@@ -258,8 +258,8 @@ class FieldAnalysisTests(TestCase):
         self.assertIsInstance(fa, FieldProfileAnalysis)
         self.assertEqual(fa.image.shape, ref_fa.image.shape)
 
-    def test_load_from_stream(self):
-        path = get_file_from_cloud_test_repo([TEST_DIR, "6x-auto-bulb-2.dcm"])
+    @requires_cloud_data(files={"path": [TEST_DIR, "6x-auto-bulb-2.dcm"]})
+    def test_load_from_stream(self, path: str):
         ref_fa = FieldProfileAnalysis(path)
         ref_fa.analyze()
         with open(path, "rb") as f:
@@ -373,8 +373,8 @@ class FieldAnalysisTests(TestCase):
         with self.assertRaises(ValueError):
             fa.analyze(normalization="limmerick")
 
-    def test_image_kwargs(self):
-        path = get_file_from_cloud_test_repo([TEST_DIR, "6x-auto-bulb-2.dcm"])
+    @requires_cloud_data(files={"path": [TEST_DIR, "6x-auto-bulb-2.dcm"]})
+    def test_image_kwargs(self, path: str):
 
         ref_fa = FieldProfileAnalysis(path)
         ref_fa.analyze()

--- a/tests_basic/test_generated_plans.py
+++ b/tests_basic/test_generated_plans.py
@@ -5,25 +5,40 @@ and listed on the Pylinac docs site for use by the public.
 
 import os
 import re
+import unittest
 from pathlib import Path
 from unittest import TestCase
 
 import pydicom
 
-from tests_basic.utils import get_folder_from_cloud_repo
+from tests_basic.utils import cloud_test_downloader, requires_cloud_data
 
 
 class TestGeneratedPlans(TestCase):
     @classmethod
+    @requires_cloud_data(
+        folders={"cloud_folder": ["rtplans"]},
+        folder_repos={"cloud_folder": "pylinac_demo_files"},
+    )
+    def _set_cloud_folder(cls, cloud_folder: str) -> None:
+        cls.cloud_folder = Path(cloud_folder)
+
+    @classmethod
     def setUpClass(cls) -> None:
         # if we're in CI/CD, download from the GCP bucket
         if os.environ.get("CI"):
-            cls.cloud_folder = get_folder_from_cloud_repo(
-                folder=["rtplans"], cloud_repo="pylinac_demo_files"
-            )
+            cls._set_cloud_folder()
         # if we're local, use the locally generated plans
         else:
-            cls.cloud_folder = Path(__file__).parent.parent / "scripts"
+            local_folder = Path(__file__).parent.parent / "scripts"
+            if len(list(local_folder.glob("R2*"))) > 0:
+                cls.cloud_folder = local_folder
+            elif cloud_test_downloader.is_authenticated:
+                cls._set_cloud_folder()
+            else:
+                raise unittest.SkipTest(
+                    "No local generated plans found and cloud test data is unavailable."
+                )
 
     def test_num_rev2_plans(self):
         self.assertEqual(len(list(Path(self.cloud_folder).glob("R2*"))), 12)

--- a/tests_basic/test_quart.py
+++ b/tests_basic/test_quart.py
@@ -18,7 +18,7 @@ from tests_basic.utils import (
     FromZipTesterMixin,
     InitTesterMixin,
     PlotlyTestMixin,
-    get_file_from_cloud_test_repo,
+    requires_cloud_data,
     save_file,
 )
 
@@ -32,23 +32,26 @@ class TestQuartDVT(TestCase, FromZipTesterMixin, InitTesterMixin, ResultsDataBas
     init_file = [*TEST_DIR, "Head"]
     is_folder = True
 
-    def test_load_from_list_of_paths(self):
+    @requires_cloud_data(files={"quart_zip": [*TEST_DIR, "Head_Quart.zip"]})
+    def test_load_from_list_of_paths(self, quart_zip: str):
         # shouldn't raise
-        with TemporaryZipDirectory(get_file_from_cloud_test_repo(self.zip)) as zfolder:
+        with TemporaryZipDirectory(quart_zip) as zfolder:
             paths = [Path(zfolder) / f for f in os.listdir(zfolder)]
             QuartDVT(paths)
 
-    def test_load_from_list_of_streams(self):
+    @requires_cloud_data(files={"quart_zip": [*TEST_DIR, "Head_Quart.zip"]})
+    def test_load_from_list_of_streams(self, quart_zip: str):
         # shouldn't raise
-        with TemporaryZipDirectory(get_file_from_cloud_test_repo(self.zip)) as zfolder:
+        with TemporaryZipDirectory(quart_zip) as zfolder:
             paths = [Path(zfolder, f) for f in os.listdir(zfolder)]
             paths = [io.BytesIO(open(p, "rb").read()) for p in paths]
             QuartDVT(paths)
 
 
 class TestQuartDVTGeneral(TestCase):
-    def setUp(self):
-        self.path = get_file_from_cloud_test_repo([*TEST_DIR, "Head_Quart.zip"])
+    @requires_cloud_data(files={"quart_zip": [*TEST_DIR, "Head_Quart.zip"]})
+    def setUp(self, quart_zip: str):
+        self.path = quart_zip
         self.quart = QuartDVT.from_zip(self.path)
 
     def test_phan_center(self):
@@ -104,9 +107,9 @@ class TestQuartDVTGeneral(TestCase):
 
 class TestPlottingSaving(TestCase):
     @classmethod
-    def setUpClass(cls):
-        path = get_file_from_cloud_test_repo([*TEST_DIR, "Head_Quart.zip"])
-        cls.quart = QuartDVT.from_zip(path)
+    @requires_cloud_data(files={"quart_zip": [*TEST_DIR, "Head_Quart.zip"]})
+    def setUpClass(cls, quart_zip: str):
+        cls.quart = QuartDVT.from_zip(quart_zip)
         cls.quart.analyze()
 
     @classmethod
@@ -464,9 +467,9 @@ class TestQuart2(QuartDVTMixin, TestCase):
 class TestQuartRollSafetyReset(TestCase):
     """Related to RAM-5972"""
 
-    def test_large_image_rotation_resets_phantom_roll_to_zero(self):
-        filename = get_file_from_cloud_test_repo([*TEST_DIR, "Head_Quart.zip"])
-        quart = QuartDVT.from_zip(filename)
+    @requires_cloud_data(files={"quart_zip": [*TEST_DIR, "Head_Quart.zip"]})
+    def test_large_image_rotation_resets_phantom_roll_to_zero(self, quart_zip: str):
+        quart = QuartDVT.from_zip(quart_zip)
         for img in quart.dicom_stack:
             img.array = ndimage.rotate(img.array, angle=15, mode="nearest")
         with self.assertWarnsRegex(
@@ -500,7 +503,7 @@ class TestQuartRAM5972(QuartDVTMixin, TestCase):
 
 class TestHypersightPhantomDepracated(TestCase):
     # This phantom is replaced by the auto-detect of the water vial on the regular Quart phantom.
-    def test_hypersight_depracated(self):
-        path = get_file_from_cloud_test_repo([*TEST_DIR, "Head_Quart.zip"])
+    @requires_cloud_data(files={"quart_zip": [*TEST_DIR, "Head_Quart.zip"]})
+    def test_hypersight_depracated(self, quart_zip: str):
         with self.assertWarns(DeprecationWarning):
-            HypersightQuartDVT.from_zip(path)
+            HypersightQuartDVT.from_zip(quart_zip)

--- a/tests_basic/test_vmat.py
+++ b/tests_basic/test_vmat.py
@@ -23,6 +23,7 @@ from tests_basic.utils import (
     FromURLTesterMixin,
     PlotlyTestMixin,
     get_file_from_cloud_test_repo,
+    requires_cloud_data,
     save_file,
 )
 
@@ -37,31 +38,47 @@ class LoadingBase(FromURLTesterMixin, FromDemoImageTesterMixin):
     klass: type[DRGS] | type[DRMLC] | type[DRCS]
     results_length: int
 
-    def test_normal_instantiation(self):
-        one = get_file_from_cloud_test_repo([TEST_DIR, "no_test_or_image_type_1.dcm"])
-        two = get_file_from_cloud_test_repo([TEST_DIR, "no_test_or_image_type_2.dcm"])
+    @requires_cloud_data(
+        files={
+            "one": [TEST_DIR, "no_test_or_image_type_1.dcm"],
+            "two": [TEST_DIR, "no_test_or_image_type_2.dcm"],
+        }
+    )
+    def test_normal_instantiation(self, one: str, two: str):
         instance = self.klass(image_paths=(one, two))
         self.assertIsInstance(instance, self.klass)
 
-    def test_from_stream(self):
-        one = get_file_from_cloud_test_repo([TEST_DIR, "no_test_or_image_type_1.dcm"])
-        two = get_file_from_cloud_test_repo([TEST_DIR, "no_test_or_image_type_2.dcm"])
+    @requires_cloud_data(
+        files={
+            "one": [TEST_DIR, "no_test_or_image_type_1.dcm"],
+            "two": [TEST_DIR, "no_test_or_image_type_2.dcm"],
+        }
+    )
+    def test_from_stream(self, one: str, two: str):
         with open(one, "rb") as s1, open(two, "rb") as s2:
             s11 = io.BytesIO(s1.read())
             s22 = io.BytesIO(s2.read())
             instance = self.klass(image_paths=(s11, s22))
         self.assertIsInstance(instance, self.klass)
 
-    def test_from_file_object(self):
-        one = get_file_from_cloud_test_repo([TEST_DIR, "no_test_or_image_type_1.dcm"])
-        two = get_file_from_cloud_test_repo([TEST_DIR, "no_test_or_image_type_2.dcm"])
+    @requires_cloud_data(
+        files={
+            "one": [TEST_DIR, "no_test_or_image_type_1.dcm"],
+            "two": [TEST_DIR, "no_test_or_image_type_2.dcm"],
+        }
+    )
+    def test_from_file_object(self, one: str, two: str):
         with open(one, "rb") as s1, open(two, "rb") as s2:
             instance = self.klass(image_paths=(s1, s2))
         self.assertIsInstance(instance, self.klass)
 
-    def test_swap_image_order(self):
-        one = get_file_from_cloud_test_repo([TEST_DIR, "no_test_or_image_type_1.dcm"])
-        two = get_file_from_cloud_test_repo([TEST_DIR, "no_test_or_image_type_2.dcm"])
+    @requires_cloud_data(
+        files={
+            "one": [TEST_DIR, "no_test_or_image_type_1.dcm"],
+            "two": [TEST_DIR, "no_test_or_image_type_2.dcm"],
+        }
+    )
+    def test_swap_image_order(self, one: str, two: str):
 
         instance = self.klass(image_paths=(one, two))
         self.assertEqual(instance.open_image.path, two)

--- a/tests_basic/utils.py
+++ b/tests_basic/utils.py
@@ -336,29 +336,119 @@ def can_run_cloud_tests() -> bool:
     return cloud_test_downloader.is_authenticated
 
 
+def _decorate_cloud_test_class(
+    cls: type,
+    file_map: dict[str, Sequence[str]],
+    folder_map: dict[str, Sequence[str]],
+    folder_repo_map: dict[str, str],
+) -> type:
+    """Wrap a ``TestCase`` class so that ``setUpClass`` injects cloud-backed
+    file and folder paths as class attributes before any test method runs.
+
+    Parameters
+    ----------
+    cls
+        The ``TestCase`` subclass to wrap.
+    file_map
+        Mapping of attribute name to cloud file path parts.
+    folder_map
+        Mapping of attribute name to cloud folder path parts.
+    folder_repo_map
+        Optional mapping of folder attribute name to cloud bucket name.
+
+    Returns
+    -------
+    type
+        The same class with a replacement ``setUpClass``.
+    """
+    original_setup_class = cls.__dict__.get("setUpClass")
+
+    @classmethod  # type: ignore[misc]
+    def new_setup_class(inner_cls: type) -> None:
+        if not can_run_cloud_tests():
+            raise unittest.SkipTest(CLOUD_TEST_SKIP_MESSAGE)
+        try:
+            for name, path in file_map.items():
+                setattr(inner_cls, name, get_file_from_cloud_test_repo(list(path)))
+            for name, path in folder_map.items():
+                setattr(
+                    inner_cls,
+                    name,
+                    get_folder_from_cloud_repo(
+                        list(path),
+                        cloud_repo=folder_repo_map.get(name, GCP_BUCKET_NAME),
+                    ),
+                )
+        except unittest.SkipTest:
+            raise
+        except Exception as exc:
+            raise unittest.SkipTest(
+                f"Cloud-backed test data unavailable: {exc}"
+            ) from exc
+        if original_setup_class is not None:
+            original_setup_class.__func__(inner_cls)
+
+    cls.setUpClass = new_setup_class
+    return cls
+
+
 def requires_cloud_data(
     *,
     files: dict[str, Sequence[str]] | None = None,
     folders: dict[str, Sequence[str]] | None = None,
     folder_repos: dict[str, str] | None = None,
 ) -> Callable:
-    """Decorator to inject cloud-backed test paths as function/classmethod kwargs.
+    """Decorator to inject cloud-backed test paths into test classes or methods.
+
+    When applied to a ``TestCase`` *class*, the decorator hooks into
+    ``setUpClass`` and injects the resolved paths as *class attributes* so
+    that every test method can access them via ``self.<name>``.  Any
+    ``setUpClass`` already defined on the class is called **after** the
+    cloud paths have been set, allowing it to use them.
+
+    When applied to a *test method*, the resolved paths are passed as
+    additional keyword arguments to the method.
 
     Parameters
     ----------
     files
-        Mapping of kwarg name to cloud file path parts.
+        Mapping of attribute/kwarg name to cloud file path parts.
     folders
-        Mapping of kwarg name to cloud folder path parts.
+        Mapping of attribute/kwarg name to cloud folder path parts.
     folder_repos
-        Optional mapping of folder kwarg name to cloud bucket name.
+        Optional mapping of folder name to the cloud bucket name to use
+        instead of the default ``GCP_BUCKET_NAME``.
+
+    Examples
+    --------
+    Class usage – shared paths become class attributes:
+
+    .. code-block:: python
+
+        @requires_cloud_data(files={"dcm_path": ["VMAT", "example.dcm"]})
+        class TestFoo(TestCase):
+            def test_something(self):
+                img = image.load(self.dcm_path)
+
+    Method usage – paths are injected as keyword arguments:
+
+    .. code-block:: python
+
+        @requires_cloud_data(files={"ct_dcm": ["CBCT", "slice.dcm"]})
+        def test_ct(self, ct_dcm: str):
+            ds = pydicom.dcmread(ct_dcm)
     """
     file_map = files or {}
     folder_map = folders or {}
     folder_repo_map = folder_repos or {}
 
-    def decorator(func: Callable) -> Callable:
-        @functools.wraps(func)
+    def decorator(func_or_cls: Callable) -> Callable:
+        if isinstance(func_or_cls, type):
+            return _decorate_cloud_test_class(
+                func_or_cls, file_map, folder_map, folder_repo_map
+            )
+
+        @functools.wraps(func_or_cls)
         def wrapper(*args: Any, **kwargs: Any):
             if not can_run_cloud_tests():
                 raise unittest.SkipTest(CLOUD_TEST_SKIP_MESSAGE)
@@ -374,13 +464,15 @@ def requires_cloud_data(
                     )
                     for name, path in folder_map.items()
                 }
+            except unittest.SkipTest:
+                raise
             except Exception as exc:
                 raise unittest.SkipTest(
                     f"Cloud-backed test data unavailable: {exc}"
                 ) from exc
             kwargs.update(injected_files)
             kwargs.update(injected_folders)
-            return func(*args, **kwargs)
+            return func_or_cls(*args, **kwargs)
 
         return wrapper
 

--- a/tests_basic/utils.py
+++ b/tests_basic/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import concurrent.futures
 import contextlib
+import functools
 import hashlib
 import multiprocessing
 import os
@@ -10,12 +11,13 @@ import os.path as osp
 import pprint
 import shutil
 import time
+import unittest
 from collections.abc import Callable, Sequence
 from functools import lru_cache
 from io import BytesIO, StringIO
 from pathlib import Path, PurePosixPath
 from tempfile import NamedTemporaryFile, TemporaryDirectory
-from typing import TypedDict
+from typing import Any, TypedDict
 from urllib.request import urlopen
 
 from google.cloud import storage
@@ -27,32 +29,82 @@ from tests_basic import DELETE_FILES
 
 GCP_BUCKET_NAME = "pylinac_test_files"
 LOCAL_TEST_DIR = "test_files"
+CLOUD_TEST_SKIP_MESSAGE = (
+    "Cloud-backed tests skipped: no cloud auth detected. "
+    "These tests auto-run when authenticated; set PYLINAC_SKIP_CLOUD_TESTS=0 "
+    "if you previously disabled them."
+)
 
 # make the local test dir if it doesn't exist
 os.makedirs(osp.join(osp.dirname(__file__), LOCAL_TEST_DIR), exist_ok=True)
 
 
+class CloudTestDataDownloader:
+    """Downloader for cloud-backed test data with auth status introspection."""
+
+    def __init__(self, bucket_name: str = GCP_BUCKET_NAME):
+        self.bucket_name = bucket_name
+        self._is_authenticated: bool | None = None
+
+    @property
+    def credentials_file(self) -> Path:
+        return Path(__file__).parent.parent / "GCP_creds.json"
+
+    @contextlib.contextmanager
+    def access_gcp(self) -> storage.Client:
+        credentials_file = self.credentials_file
+        # check if the credentials file is available (local dev)
+        # if not, load from the env var (test pipeline)
+        if not credentials_file.is_file():
+            with open(credentials_file, "wb") as f:
+                creds = base64.b64decode(os.environ.get("GOOGLE_CREDENTIALS", ""))
+                f.write(creds)
+        client = storage.Client.from_service_account_json(str(credentials_file))
+        try:
+            yield client
+        finally:
+            del client
+
+    def _compute_authentication_status(self) -> bool:
+        try:
+            with self.access_gcp() as client:
+                client.bucket(self.bucket_name).reload()
+            return True
+        except Exception:
+            return False
+
+    @property
+    def is_authenticated(self) -> bool:
+        if self._is_authenticated is None:
+            self._is_authenticated = self._compute_authentication_status()
+        return self._is_authenticated
+
+    def reset_auth_cache(self) -> None:
+        self._is_authenticated = None
+
+
+cloud_test_downloader = CloudTestDataDownloader()
+
+
 @contextlib.contextmanager
 def access_gcp() -> storage.Client:
-    # access GCP
-    credentials_file = Path(__file__).parent.parent / "GCP_creds.json"
-    # check if the credentials file is available (local dev)
-    # if not, load from the env var (test pipeline)
-    if not credentials_file.is_file():
-        with open(credentials_file, "wb") as f:
-            creds = base64.b64decode(os.environ.get("GOOGLE_CREDENTIALS", ""))
-            f.write(creds)
-    client = storage.Client.from_service_account_json(str(credentials_file))
-    try:
+    with cloud_test_downloader.access_gcp() as client:
         yield client
-    finally:
-        del client
 
 
 @lru_cache
 def gcp_bucket_object_list(bucket_name: str) -> list:
-    with access_gcp() as storage_client:
-        return list(storage_client.list_blobs(bucket_name))
+    if not can_run_cloud_tests():
+        raise unittest.SkipTest(CLOUD_TEST_SKIP_MESSAGE)
+    try:
+        with access_gcp() as storage_client:
+            return list(storage_client.list_blobs(bucket_name))
+    except unittest.SkipTest:
+        raise
+    except Exception as exc:
+        if os.environ.get("CI"):
+            raise
+        raise unittest.SkipTest(f"Cloud-backed test data unavailable: {exc}") from exc
 
 
 def get_folder_from_cloud_repo(
@@ -75,11 +127,21 @@ def get_folder_from_cloud_repo(
     cloud_repo
         The GCP bucket to download from.
     """
+    if not can_run_cloud_tests():
+        raise unittest.SkipTest(CLOUD_TEST_SKIP_MESSAGE)
+
     dest_folder = Path(local_dir, *folder)
     if skip_exists and dest_folder.exists() and len(list(dest_folder.iterdir())) > 0:
         return str(dest_folder)
     # get the folder data
-    all_blobs = gcp_bucket_object_list(cloud_repo)
+    try:
+        all_blobs = gcp_bucket_object_list(cloud_repo)
+    except unittest.SkipTest:
+        raise
+    except Exception as exc:
+        if os.environ.get("CI"):
+            raise
+        raise unittest.SkipTest(f"Cloud-backed test data unavailable: {exc}") from exc
     blobs = (
         Enumerable(all_blobs)
         .where(lambda b: len(b.name.split("/")) > len(folder))
@@ -145,7 +207,9 @@ def _load_blob_metadata(blob: storage.Blob) -> None:
     blob.reload()
 
 
-def get_file_from_cloud_test_repo(path: list[str], force: bool = False) -> str:
+def _download_file_from_cloud_test_repo(
+    path: tuple[str, ...], force: bool = False
+) -> str:
     """Get a single file from GCP storage. Returns the path to disk it was downloaded to"""
     local_filename = osp.join(osp.dirname(__file__), LOCAL_TEST_DIR, *path)
     local_path = Path(local_filename)
@@ -217,12 +281,110 @@ def get_file_from_cloud_test_repo(path: list[str], force: bool = False) -> str:
         return local_filename
 
 
+@lru_cache(maxsize=512)
+def _cached_file_from_cloud_test_repo(path: tuple[str, ...]) -> str:
+    return _download_file_from_cloud_test_repo(path=path, force=False)
+
+
+def get_file_from_cloud_test_repo(path: Sequence[str], force: bool = False) -> str:
+    """Get a single file from GCP storage and return the local file path.
+
+    Parameters
+    ----------
+    path
+        Cloud path parts inside the test-data bucket.
+    force
+        If ``True``, skip the in-memory cache and force a fresh validation/download cycle.
+    """
+    if not can_run_cloud_tests():
+        raise unittest.SkipTest(CLOUD_TEST_SKIP_MESSAGE)
+    normalized_path = tuple(path)
+    try:
+        if force:
+            return _download_file_from_cloud_test_repo(path=normalized_path, force=True)
+        return _cached_file_from_cloud_test_repo(normalized_path)
+    except unittest.SkipTest:
+        raise
+    except Exception as exc:
+        if os.environ.get("CI"):
+            raise
+        raise unittest.SkipTest(f"Cloud-backed test data unavailable: {exc}") from exc
+
+
 def has_www_connection():
     try:
         with urlopen("http://www.google.com") as r:
             return r.status == 200
     except Exception:
         return False
+
+
+def can_run_cloud_tests() -> bool:
+    """Return whether cloud-backed tests can be run.
+
+    Set ``PYLINAC_SKIP_CLOUD_TESTS`` to ``1``/``true``/``yes`` to force skipping.
+    """
+    env_skip = os.environ.get("PYLINAC_SKIP_CLOUD_TESTS", "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    if env_skip:
+        return False
+    if os.environ.get("CI"):
+        return True
+    return cloud_test_downloader.is_authenticated
+
+
+def requires_cloud_data(
+    *,
+    files: dict[str, Sequence[str]] | None = None,
+    folders: dict[str, Sequence[str]] | None = None,
+    folder_repos: dict[str, str] | None = None,
+) -> Callable:
+    """Decorator to inject cloud-backed test paths as function/classmethod kwargs.
+
+    Parameters
+    ----------
+    files
+        Mapping of kwarg name to cloud file path parts.
+    folders
+        Mapping of kwarg name to cloud folder path parts.
+    folder_repos
+        Optional mapping of folder kwarg name to cloud bucket name.
+    """
+    file_map = files or {}
+    folder_map = folders or {}
+    folder_repo_map = folder_repos or {}
+
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any):
+            if not can_run_cloud_tests():
+                raise unittest.SkipTest(CLOUD_TEST_SKIP_MESSAGE)
+            try:
+                injected_files = {
+                    name: get_file_from_cloud_test_repo(path)
+                    for name, path in file_map.items()
+                }
+                injected_folders = {
+                    name: get_folder_from_cloud_repo(
+                        list(path),
+                        cloud_repo=folder_repo_map.get(name, GCP_BUCKET_NAME),
+                    )
+                    for name, path in folder_map.items()
+                }
+            except Exception as exc:
+                raise unittest.SkipTest(
+                    f"Cloud-backed test data unavailable: {exc}"
+                ) from exc
+            kwargs.update(injected_files)
+            kwargs.update(injected_folders)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 def save_file(method, *args, as_file_object=None, to_single_file=True, **kwargs):


### PR DESCRIPTION
## Summary

This PR improves how cloud-backed tests are executed and maintained by standardizing around `requires_cloud_data` and making cloud auth behavior explicit and reliable.

### What’s new

- Added auth-aware cloud test control in `tests_basic/utils.py`:
  - Introduced a downloader/auth helper with cached auth detection.
  - Added/updated skip policy so cloud-backed tests skip cleanly when auth is unavailable.
  - Added environment override support via `PYLINAC_SKIP_CLOUD_TESTS`.
  - Preserved CI behavior so cloud tests still run in CI contexts.

- Enhanced `requires_cloud_data` so it can fully support both:
  - **method-level injection** (kwargs into tests), and
  - **class-level usage** (inject cloud paths before class setup).

- Refactored `tests_basic/core/test_image.py`:
  - Removed local cloud-data decorator infrastructure.
  - Migrated to `requires_cloud_data` usage only.
  - Updated tests to use injected attributes/kwargs instead of local module-level cloud path plumbing.

- Migrated additional cloud-backed tests across modules to use the shared decorator pattern and centralized skip/auth behavior.

- Added `GCP_creds.json` to `.gitignore`.

## Why

This reduces duplicated cloud-test setup logic, improves test readability, and makes local execution behavior more predictable when cloud credentials are absent.

## Validation

- `uvx prek run --directory tests_basic`

## Related

- Closes #543