### PR TITLE
Cleanup/stray files created by tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,7 @@ $RECYCLE.BIN/
 *.lnk
 
 tests_basic/test_files
+
+# Test-run telemetry written by conftest.py (best-effort; cleaned up at session end)
+active_tests.json
+active_tests.json.*.tmp

--- a/tests_basic/test_field_analysis.py
+++ b/tests_basic/test_field_analysis.py
@@ -157,10 +157,17 @@ class FieldAnalysisTests(QuaacTestBase, TestCase):
         fs.analyze()
         figs, names = fs.plot_analyzed_image(split_plots=True)
         self.assertEqual(len(figs), 3)
-        files = fs.save_analyzed_image(filename="a.png", split_plots=True)
-        names = ("aImage.png", "aVertical Profile.png", "aHorizontal Profile.png")
-        for name in names:
-            self.assertIn(name, files)
+        with tempfile.TemporaryDirectory() as tdir:
+            base = os.path.join(tdir, "a.png")
+            files = fs.save_analyzed_image(filename=base, split_plots=True)
+            stem = osp.splitext(base)[0]
+            expected = (
+                stem + "Image.png",
+                stem + "Vertical Profile.png",
+                stem + "Horizontal Profile.png",
+            )
+            for name in expected:
+                self.assertIn(name, files)
 
         # regular single plot produces one image/file
         figs, names = fs.plot_analyzed_image()

--- a/tests_basic/test_picketfence.py
+++ b/tests_basic/test_picketfence.py
@@ -378,30 +378,34 @@ class TestBBBasedAnalysis(TestCase):
     def test_bb_pf_combo(self):
         wl = create_bb_image(field_size=(50, 50), bb_size=5, offset=(2, 2))
         bb_img = DicomImage.from_dataset(wl)
-        bb_img.save("bb_setup.dcm")
 
-        pf_file = "separated_wide_gap_up_down.dcm"
-        generate_picketfence(
-            simulator=AS1200Image(sid=1000),
-            field_layer=FilteredFieldLayer,
-            # this applies a non-uniform intensity about the CAX, simulating the horn effect
-            file_out=pf_file,
-            final_layers=[
-                GaussianFilterLayer(sigma_mm=1),
-            ],
-            pickets=5,
-            picket_spacing_mm=50,
-            picket_width_mm=20,  # wide-ish gap
-            orientation=Orientation.UP_DOWN,
-        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bb_file = osp.join(tmpdir, "bb_setup.dcm")
+            pf_file = osp.join(tmpdir, "pf.dcm")
+            bb_img.save(bb_file)
+            generate_picketfence(
+                simulator=AS1200Image(sid=1000),
+                field_layer=FilteredFieldLayer,
+                # this applies a non-uniform intensity about the CAX, simulating the horn effect
+                file_out=pf_file,
+                final_layers=[
+                    GaussianFilterLayer(sigma_mm=1),
+                ],
+                pickets=5,
+                picket_spacing_mm=50,
+                picket_width_mm=20,  # wide-ish gap
+                orientation=Orientation.UP_DOWN,
+            )
 
-        pf = PicketFence.from_bb_setup(pf_file, bb_image="bb_setup.dcm", bb_diameter=5)
-        pf.analyze(separate_leaves=False)
-        results = pf.results_data()
-        self.assertAlmostEqual(results.max_error_mm, 0.0, delta=0.005)
-        self.assertAlmostEqual(results.cax.x, 636.5, delta=0.1)
-        # bb is 2mm off in bb setup image above
-        self.assertAlmostEqual(results.mlc_positions_by_leaf["17"][0], 102, delta=0.1)
+            pf = PicketFence.from_bb_setup(pf_file, bb_image=bb_file, bb_diameter=5)
+            pf.analyze(separate_leaves=False)
+            results = pf.results_data()
+            self.assertAlmostEqual(results.max_error_mm, 0.0, delta=0.005)
+            self.assertAlmostEqual(results.cax.x, 636.5, delta=0.1)
+            # bb is 2mm off in bb setup image above
+            self.assertAlmostEqual(
+                results.mlc_positions_by_leaf["17"][0], 102, delta=0.1
+            )
 
     def test_invert_bb_image(self):
         # See RM-5424

--- a/tests_basic/test_planar_imaging.py
+++ b/tests_basic/test_planar_imaging.py
@@ -163,17 +163,24 @@ class GeneralTests(TestCase):
         phan.analyze()
         figs, names = phan.plot_analyzed_image(split_plots=True)
         self.assertEqual(len(figs), 3)
-        files = phan.save_analyzed_image(filename="a.png", split_plots=True)
-        names = ("a_image.png", "a_low_contrast.png", "a_high_contrast.png")
-        for name in names:
-            self.assertIn(name, files)
+        with tempfile.TemporaryDirectory() as tdir:
+            base = os.path.join(tdir, "a.png")
+            files = phan.save_analyzed_image(filename=base, split_plots=True)
+            stem = osp.splitext(base)[0]
+            expected = (
+                stem + "_image.png",
+                stem + "_low_contrast.png",
+                stem + "_high_contrast.png",
+            )
+            for name in expected:
+                self.assertIn(name, files)
 
-        # regular single plot produces one image/file
-        figs, names = phan.plot_analyzed_image()
-        self.assertEqual(len(figs), 0)
-        name = "b.png"
-        phan.save_analyzed_image("b.png")
-        self.assertTrue(osp.isfile(name))
+            # regular single plot produces one image/file
+            figs, names = phan.plot_analyzed_image()
+            self.assertEqual(len(figs), 0)
+            name = os.path.join(tdir, "b.png")
+            phan.save_analyzed_image(name)
+            self.assertTrue(osp.isfile(name))
 
         # stream buffer shouldn't fail
         with io.BytesIO() as tmp:


### PR DESCRIPTION
While working on https://github.com/jrkerns/pylinac/pull/599 I found some tests polluting the document root with files, this addresses files being created by unit tests